### PR TITLE
Give error messages to users for literals which cannot be parsed

### DIFF
--- a/src/compiler/lexer/error.rs
+++ b/src/compiler/lexer/error.rs
@@ -1,3 +1,5 @@
+use std::num::{ParseIntError, ParseFloatError};
+
 use crate::compiler::{
     source::SourceChar, CompilerDisplay, CompilerDisplayError, SourceError, SourceMap,
 };
@@ -13,6 +15,8 @@ pub enum LexerError {
     ExpectedEscapeCharacter,
     InvalidNumber,
     InvalidSuffixOnFloat,
+    ParseIntError(Primitive, ParseIntError),
+    ParseFloatError(Primitive, ParseFloatError),
     UnexpectedSuffixType(Primitive),
     SourceError, // TODO: make this more descriptive
 }
@@ -30,6 +34,8 @@ impl CompilerDisplay for LexerError {
             SourceError => format!("Error reading characters from source code"),
             UnexpectedEof => format!("Unexpected EOF"),
             InvalidSuffixOnFloat => format!("Invalid suffix after float literal."),
+            ParseIntError(p, e) => format!("{} of {}", e, p),
+            ParseFloatError(p, e) => format!("{} of {}", e, p),
         };
 
         Ok(format!("{}", msg))
@@ -39,5 +45,12 @@ impl CompilerDisplay for LexerError {
 impl From<SourceError> for LexerError {
     fn from(_: SourceError) -> Self {
         Self::SourceError
+    }
+}
+
+impl From<ParseIntError> for LexerError {
+    fn from(e: ParseIntError) -> Self {
+        format!("{:?}", e);
+        Self::InvalidNumber
     }
 }

--- a/src/compiler/lexer/lexer.rs
+++ b/src/compiler/lexer/lexer.rs
@@ -703,34 +703,52 @@ impl<'a> Lexer<'a> {
         prim: Primitive,
     ) -> LexerResult<Option<Token>> {
         match prim {
-            Primitive::U8 => Ok(Some(Token::new(U8(int_token.parse::<u8>().unwrap()), span))),
+            Primitive::U8 => Ok(Some(Token::new(U8(int_token.parse::<u8>().map_err(|e|
+                    CompilerError::new(span, LexerError::ParseIntError(Primitive::U8, e))
+                )?), span))),
             Primitive::U16 => Ok(Some(Token::new(
-                U16(int_token.parse::<u16>().unwrap()),
+                U16(int_token.parse::<u16>().map_err(|e|
+                    CompilerError::new(span, LexerError::ParseIntError(Primitive::U16, e ))
+                )?),
                 span,
             ))),
             Primitive::U32 => Ok(Some(Token::new(
-                U32(int_token.parse::<u32>().unwrap()),
+                U32(int_token.parse::<u32>().map_err(|e|
+                    CompilerError::new(span, LexerError::ParseIntError(Primitive::U32, e))
+                )?),
                 span,
             ))),
             Primitive::U64 => Ok(Some(Token::new(
-                U64(int_token.parse::<u64>().unwrap()),
+                U64(int_token.parse::<u64>().map_err(|e|
+                    CompilerError::new(span, LexerError::ParseIntError(Primitive::U64, e))
+                )?),
                 span,
             ))),
-            Primitive::I8 => Ok(Some(Token::new(I8(int_token.parse::<i8>().unwrap()), span))),
+            Primitive::I8 => Ok(Some(Token::new(I8(int_token.parse::<i8>().map_err(|e|
+                    CompilerError::new(span, LexerError::ParseIntError(Primitive::I8, e))
+                )?), span))),
             Primitive::I16 => Ok(Some(Token::new(
-                I16(int_token.parse::<i16>().unwrap()),
+                I16(int_token.parse::<i16>().map_err(|e|
+                    CompilerError::new(span, LexerError::ParseIntError(Primitive::I16, e))
+                )?),
                 span,
             ))),
             Primitive::I32 => Ok(Some(Token::new(
-                I32(int_token.parse::<i32>().unwrap()),
+                I32(int_token.parse::<i32>().map_err(|e|
+                    CompilerError::new(span, LexerError::ParseIntError(Primitive::I32, e))
+                )?),
                 span,
             ))),
             Primitive::I64 => Ok(Some(Token::new(
-                I64(int_token.parse::<i64>().unwrap()),
+                I64(int_token.parse::<i64>().map_err(|e|
+                    CompilerError::new(span, LexerError::ParseIntError(Primitive::I64, e))
+                )?),
                 span,
             ))),
             Primitive::F64 => Ok(Some(Token::new(
-                F64(int_token.parse::<f64>().unwrap()),
+                F64(int_token.parse::<f64>().map_err(|e|
+                    CompilerError::new(span, LexerError::ParseFloatError(Primitive::F64, e))
+                )?),
                 span,
             ))),
             Primitive::Bool | Primitive::StringLiteral => {


### PR DESCRIPTION
Instead of faulting, propagate an error up to users when an integer literal or float literal cannot be parsed.