### PR TITLE
I278 null in struct expr

### DIFF
--- a/src/compiler/ast/ty.rs
+++ b/src/compiler/ast/ty.rs
@@ -43,6 +43,15 @@ pub enum PointerMut {
     Const,
 }
 
+impl std::fmt::Display for PointerMut {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PointerMut::Mut => f.write_str("mut"),
+            PointerMut::Const => f.write_str("const"),
+        }
+    }
+}
+
 impl Type {
     /// Returns `true` if the the provided type can be assigned
     /// to variables of this [`Type`].
@@ -256,6 +265,7 @@ impl CompilerDisplay for Type {
             Type::Custom(path) => path.fmt(sm, st),
             Type::Coroutine(ty) => Ok(format!("co<{}>", ty.fmt(sm, st)?)),
             Type::Array(ty, sz) => Ok(format!("[{}; {}]", ty.fmt(sm, st)?, sz)),
+            Type::RawPointer(m, ty) => Ok(format!("*{} {}", m, ty.fmt(sm, st)?)),
             Type::ExternDecl(params, has_varargs, ret_ty) => {
                 let mut params = params
                     .iter()

--- a/src/compiler/ast/ty.rs
+++ b/src/compiler/ast/ty.rs
@@ -55,7 +55,14 @@ impl Type {
             Self::RawPointer(..) => {
                 r == &Self::Null || self == r
             },
-            Self::Null => false,
+            Self::Null => r == &Self::Null || r.can_be_assigned(&Self::Null),
+            Self::Array(ty, sz) => {
+                if let Self::Array(rty, rsz) = r {
+                    sz == rsz && ty.can_be_assigned(rty)
+                } else {
+                    false
+                }
+            }
             _ => self == r,
         }
     }
@@ -68,7 +75,7 @@ impl Type {
                 r == &Self::Null || self == r
             },
             Self::Null => {
-                r == &Self::Null || r.can_be_compared(self)
+                r == &Self::Null || r.can_be_compared(&Self::Null)
             }
             _ => self == r,
         }

--- a/src/compiler/semantics/tests/type_resolver.rs
+++ b/src/compiler/semantics/tests/type_resolver.rs
@@ -1830,12 +1830,12 @@ let tokens: Vec<Token> = Lexer::new(src, &mut table, &logger).unwrap()
                 Ok(Type::U16),
             ),
             (
-                "fn main() -> u16 {
+                "fn main() -> *const u16 {
                     let a: [*const u16; 5] := [null, null, null, null, null];
-                    let k: u16 := a[0];
-                    return k * 3u16;
+                    let k: *const u16 := a[0];
+                    return k;
                 }",
-                Ok(Type::U16),
+                Ok(Type::RawPointer(PointerMut::Const, Box::new(Type::U16))),
             ),
             (
                 "fn main() -> i16 {

--- a/src/compiler/semantics/tests/type_resolver.rs
+++ b/src/compiler/semantics/tests/type_resolver.rs
@@ -1830,6 +1830,14 @@ let tokens: Vec<Token> = Lexer::new(src, &mut table, &logger).unwrap()
                 Ok(Type::U16),
             ),
             (
+                "fn main() -> u16 {
+                    let a: [*const u16; 5] := [null, null, null, null, null];
+                    let k: u16 := a[0];
+                    return k * 3u16;
+                }",
+                Ok(Type::U16),
+            ),
+            (
                 "fn main() -> i16 {
                     let a: [i16; 2] := [1, 2,];
                     let k: i16 := a[0];
@@ -3128,6 +3136,16 @@ let tokens: Vec<Token> = Lexer::new(src, &mut table, &logger).unwrap()
                 fn test() -> MyStruct 
                 {
                     let x: root::MyStruct := MyStruct{x: 1};
+                    return x;
+                }",
+                Ok(()),
+            ),
+            (
+                line!(),
+                "struct MyStruct{x:*const i64}
+                fn test() -> MyStruct 
+                {
+                    let x: root::MyStruct := MyStruct{x: null};
                     return x;
                 }",
                 Ok(()),

--- a/src/compiler/semantics/type_resolver.rs
+++ b/src/compiler/semantics/type_resolver.rs
@@ -504,7 +504,7 @@ impl<'a> TypeResolver<'a> {
                 } else {
                     el_ty = nelements[0].context().ty().clone();
                     for e in &nelements {
-                        if e.context().ty() != el_ty {
+                        if !e.context().ty().can_be_assigned(&el_ty) {
                             return Err(CompilerError::new(
                                 ctx.span(),
                                 SemanticError::ArrayInconsistentElementTypes,

--- a/src/compiler/semantics/type_resolver.rs
+++ b/src/compiler/semantics/type_resolver.rs
@@ -864,7 +864,7 @@ impl<'a> TypeResolver<'a> {
                         SemanticError::StructExprMemberNotFound(canonical_path.clone(), *pn),
                     ))?;
                     let param = self.analyze_expression(pv)?;
-                    if param.get_type().can_be_assigned(member_ty) {
+                    if !member_ty.can_be_assigned(param.get_type()) {
                         return Err(CompilerError::new(
                             ctx.span(),
                             SemanticError::StructExprFieldTypeMismatch(

--- a/src/compiler/semantics/type_resolver.rs
+++ b/src/compiler/semantics/type_resolver.rs
@@ -864,7 +864,7 @@ impl<'a> TypeResolver<'a> {
                         SemanticError::StructExprMemberNotFound(canonical_path.clone(), *pn),
                     ))?;
                     let param = self.analyze_expression(pv)?;
-                    if param.get_type() != member_ty {
+                    if param.get_type().can_be_assigned(member_ty) {
                         return Err(CompilerError::new(
                             ctx.span(),
                             SemanticError::StructExprFieldTypeMismatch(


### PR DESCRIPTION
Closes #278. This fixes the type checker to allow `null` to be used in struct expressions and array expressions when the needed type is a const or mut raw pointer.