### PR TITLE
T42 Span Information

### DIFF
--- a/src/compiler/mir/ir.rs
+++ b/src/compiler/mir/ir.rs
@@ -44,8 +44,8 @@ impl Procedure {
     }
 
     /// Add an argument to this procedure
-    pub fn add_arg(&mut self, name: StringId, ty: &Type) -> VarId {
-        let vd = VarDecl::new(name, false, ty, ScopeId::new(ROOT_SCOPE));
+    pub fn add_arg(&mut self, name: StringId, ty: &Type, span: Span) -> VarId {
+        let vd = VarDecl::new(name, false, ty, ScopeId::new(ROOT_SCOPE), span);
         self.vars.push(vd);
         let id = self.vars.len() - 1;
         VarId::new(id)
@@ -94,8 +94,8 @@ impl Procedure {
     }
 
     /// Add a new user defined variable to the procedure.
-    pub fn add_var(&mut self, name: StringId, mutable: bool, ty: &Type, scope: ScopeId) -> VarId {
-        let vd = VarDecl::new(name, mutable, ty, scope);
+    pub fn add_var(&mut self, name: StringId, mutable: bool, ty: &Type, scope: ScopeId, span: Span) -> VarId {
+        let vd = VarDecl::new(name, mutable, ty, scope, span);
         self.vars.push(vd);
         let id = self.vars.len() - 1;
 
@@ -121,11 +121,13 @@ impl Display for Procedure {
         // Print out the variables
         for idx in 0..self.vars.len() {
             let vid = VarId::new(idx);
+            f.write_str("let ")?;
+
             if self.vars[idx].mutable {
-                f.write_fmt(format_args!("let mut {}: {:?} // {}\n", vid, self.vars[idx].ty, self.vars[idx].name))?
-            } else {
-                f.write_fmt(format_args!("let {}: {:?} // {}\n", vid, self.vars[idx].ty, self.vars[idx].name))?
+                f.write_str("mut ")?
             }
+
+            f.write_fmt(format_args!("{}: {:?} // {} {}\n", vid, self.vars[idx].ty, self.vars[idx].name, self.vars[idx].span))?
         }
         f.write_str("\n")?;
         
@@ -231,15 +233,18 @@ pub struct VarDecl {
     ty: Type,
     /// What scope this variable was declared in
     scope: ScopeId,
+    /// The span of code where this variable was declared
+    span: Span
 }
 
 impl VarDecl {
-    pub fn new(name: StringId, mutable: bool, ty: &Type, scope: ScopeId) -> VarDecl {
+    pub fn new(name: StringId, mutable: bool, ty: &Type, scope: ScopeId, span: Span) -> VarDecl {
         VarDecl {
             name,
             mutable,
             ty: ty.clone(),
             scope,
+            span,
         }
     }
 }

--- a/src/compiler/mir/ir.rs
+++ b/src/compiler/mir/ir.rs
@@ -39,6 +39,10 @@ impl Procedure {
         }
     }
 
+    pub fn set_span(&mut self, span: Span) {
+        self.span = span;
+    }
+
     /// Add an argument to this procedure
     pub fn add_arg(&mut self, name: StringId, ty: &Type) -> VarId {
         let vd = VarDecl::new(name, false, ty, ScopeId::new(ROOT_SCOPE));
@@ -307,10 +311,10 @@ impl BasicBlock {
 impl Display for BasicBlock {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for stm in &self.statements {
-            f.write_fmt(format_args!("{}\n", stm))?
+            f.write_fmt(format_args!("{}  // {}\n", stm, stm.span))?
         }
         match &self.terminator {
-            Some(term) => f.write_fmt(format_args!("{}\n", term)),
+            Some(term) => f.write_fmt(format_args!("{} // {}\n", term, term.span)),
             None => f.write_fmt(format_args!("MISSING TERMINATOR\n")),
         }
     }
@@ -329,10 +333,10 @@ pub struct Statement {
 }
 
 impl Statement {
-    pub fn new(kind: StatementKind) -> Statement {
+    pub fn new(kind: StatementKind, span: Span) -> Statement {
         Statement {
             kind,
-            span: Span::zero(),
+            span,
         }
     }
 }
@@ -488,10 +492,10 @@ pub struct Terminator {
 }
 
 impl Terminator {
-    pub fn new(kind: TerminatorKind) -> Terminator {
+    pub fn new(kind: TerminatorKind, span: Span) -> Terminator {
         Terminator {
             kind,
-            span: Span::zero(),
+            span,
         }
     }
 }

--- a/src/compiler/mir/test.rs
+++ b/src/compiler/mir/test.rs
@@ -41,7 +41,7 @@ pub mod tests {
         let text = "
         fn test() -> i64 {
             let x: i64 := 5;
-            let b: bool := true;
+            let mut b: bool := true;
             let y: i64 := if (b) {13} else {29};
             return 1 + 2 + 3 + x + y;
         }

--- a/src/compiler/mir/transform.rs
+++ b/src/compiler/mir/transform.rs
@@ -11,7 +11,7 @@ use log::debug;
 
 use crate::{
     compiler::{
-        ast::{BinaryOperator, Bind, Expression, Module, Return, RoutineDef, Statement, Type},
+        ast::{BinaryOperator, Bind, Expression, Module, Return, RoutineDef, Statement, Type, Context, Node},
         semantics::semanticnode::SemanticContext,
         Span,
     },
@@ -85,19 +85,19 @@ impl MirBuilder {
         self.proc.add_temp(ty)
     }
 
-    fn temp_store(&mut self, rv: RValue, ty: &Type) -> Operand {
+    fn temp_store(&mut self, rv: RValue, ty: &Type, span: Span) -> Operand {
         let tv = LValue::Temp(self.temp(ty));
         debug!("Temp store: {:?} := {:?}", tv, rv);
 
-        self.store(tv.clone(), rv);
+        self.store(tv.clone(), rv, span);
 
         Operand::LValue(tv)
     }
 
-    fn store(&mut self, lv: LValue, rv: RValue) {
+    fn store(&mut self, lv: LValue, rv: RValue, span: Span) {
         let cid = self.current_bb.unwrap();
         let bb = self.proc.get_bb_mut(cid);
-        bb.add_stm(super::ir::Statement::new(StatementKind::Assign(lv, rv)));
+        bb.add_stm(super::ir::Statement::new(StatementKind::Assign(lv, rv), span));
     }
 
     fn sub(&mut self) {
@@ -117,23 +117,23 @@ impl MirBuilder {
     }
 
     /// Terminates by returning to the caller function
-    fn term_return(&mut self) {
+    fn term_return(&mut self, span: Span) {
         debug!("Terminator: Return");
         let cid = self.current_bb.unwrap();
         let bb = self.proc.get_bb_mut(cid);
-        bb.set_terminator(Terminator::new(TerminatorKind::Return));
+        bb.set_terminator(Terminator::new(TerminatorKind::Return, span));
     }
 
     /// Terminates by going to the destination basic block
-    fn term_goto(&mut self, target: BasicBlockId) {
+    fn term_goto(&mut self, target: BasicBlockId, span: Span) {
         debug!("Goto: {:?}", target);
         let cid = self.current_bb.unwrap();
         let bb = self.proc.get_bb_mut(cid);
-        bb.set_terminator(Terminator::new(TerminatorKind::GoTo { target }))
+        bb.set_terminator(Terminator::new(TerminatorKind::GoTo { target }, span))
     }
 
     /// Terminates with a conditional go to
-    fn term_cond_goto(&mut self, cond: Operand, then_bb: BasicBlockId, else_bb: BasicBlockId) {
+    fn term_cond_goto(&mut self, cond: Operand, then_bb: BasicBlockId, else_bb: BasicBlockId, span: Span) {
         debug!("If {:?} then {:?} else {:?}", cond, then_bb, else_bb);
         let cid = self.current_bb.unwrap();
         let bb = self.proc.get_bb_mut(cid);
@@ -141,7 +141,7 @@ impl MirBuilder {
             cond,
             tru: then_bb,
             fls: else_bb,
-        }));
+        }, span));
     }
 
     /// Terminates by calling the given function
@@ -164,6 +164,8 @@ impl FuncTransformer {
     }
 
     pub fn transform(mut self, func: &RoutineDef<SemanticContext>) -> Procedure {
+        self.mir.proc.set_span(func.context.span());
+
         // Create a new MIR Procedure
         // Create a BasicBlock for the function
         let bb = self.mir.new_bb();
@@ -173,7 +175,7 @@ impl FuncTransformer {
         func.body.iter().for_each(|stm| self.statement(stm));
 
         // Add the return from function as the terminator for the final basic block of the function
-        self.mir.term_return();
+        self.mir.term_return(Span::zero());
         self.mir.proc
     }
 
@@ -199,18 +201,18 @@ impl FuncTransformer {
 
         let expr = self.expression(bind.get_rhs());
 
-        self.mir.store(LValue::Var(vid), RValue::Use(expr))
+        self.mir.store(LValue::Var(vid), RValue::Use(expr), bind.context().span())
     }
 
     fn ret(&mut self, ret: &Return<SemanticContext>) {
         match ret.get_value() {
             Some(val) => {
                 let v = self.expression(val);
-                self.mir.store(LValue::ReturnPointer, RValue::Use(v));
+                self.mir.store(LValue::ReturnPointer, RValue::Use(v), val.context().span());
             }
             None => (),
         };
-        self.mir.term_return();
+        self.mir.term_return(ret.context().span());
     }
 
     /// This can return either an Operand or an RValue, if this is evaluating a constant or an identifier
@@ -220,7 +222,7 @@ impl FuncTransformer {
             Expression::I64(_, i) => self.mir.const_i64(*i),
             Expression::BinaryOp(ctx, op, left, right) => {
                 let rv = self.binary_op(*op, left, right);
-                self.mir.temp_store(rv, ctx.ty())
+                self.mir.temp_store(rv, ctx.ty(), ctx.span())
             }
             Expression::Null(_) => todo!(),
             Expression::U8(_, _) => todo!(),
@@ -296,9 +298,9 @@ impl FuncTransformer {
         // If there is an else block then jump to the else block on false
         // otherwise jump to the merge block
         if let Some(else_bb) = &else_bb {
-            self.mir.term_cond_goto(cond_val, then_bb, else_bb.1);
+            self.mir.term_cond_goto(cond_val, then_bb, else_bb.1, cond.context().span());
         } else {
-            self.mir.term_cond_goto(cond_val, then_bb, merge_bb);
+            self.mir.term_cond_goto(cond_val, then_bb, merge_bb, cond.context().span());
         }
 
         // Only create a temp location if this if expression can resolve to a
@@ -311,15 +313,15 @@ impl FuncTransformer {
 
         self.mir.set_bb(then_bb);
         let val = self.expression(then_block);
-        result.map(|t| self.mir.store(LValue::Temp(t), RValue::Use(val)));
-        self.mir.term_goto(merge_bb);
+        result.map(|t| self.mir.store(LValue::Temp(t), RValue::Use(val), then_block.context().span()));
+        self.mir.term_goto(merge_bb, Span::zero());
 
         // If there is an else block, then construct it
         if let Some((else_block, else_bb)) = else_bb {
             self.mir.set_bb(else_bb);
             let val = self.expression(else_block);
-            result.map(|t| self.mir.store(LValue::Temp(t), RValue::Use(val)));
-            self.mir.term_goto(merge_bb);
+            result.map(|t| self.mir.store(LValue::Temp(t), RValue::Use(val), else_block.context().span()));
+            self.mir.term_goto(merge_bb, Span::zero());
         }
 
         self.mir.set_bb(merge_bb);

--- a/src/compiler/mir/transform.rs
+++ b/src/compiler/mir/transform.rs
@@ -81,8 +81,8 @@ impl MirBuilder {
         Operand::Constant(Constant::Bool(b))
     }
 
-    fn var(&mut self, name: StringId, mutable: bool, ty: &Type) -> VarId {
-        self.proc.add_var(name, mutable, ty, ScopeId::new(0))
+    fn var(&mut self, name: StringId, mutable: bool, ty: &Type, span: Span) -> VarId {
+        self.proc.add_var(name, mutable, ty, ScopeId::new(0), span)
     }
 
     fn temp(&mut self, ty: &Type) -> TempId {
@@ -213,7 +213,7 @@ impl FuncTransformer {
         let var = bind.get_id();
         let mutable = bind.is_mutable();
         let ty = bind.get_type();
-        let vid = self.mir.var(var, mutable, ty);
+        let vid = self.mir.var(var, mutable, ty, bind.context().span());
 
         let expr = self.expression(bind.get_rhs());
 

--- a/src/compiler/mir/transform.rs
+++ b/src/compiler/mir/transform.rs
@@ -404,7 +404,6 @@ fn span_end(span: Span) -> Span {
     if high == 0 {
         Span::zero()
     } else {
-        let low = high - 1;
-        Span::new(Offset::new(low), Offset::new(high))
+        Span::new(Offset::new(high), Offset::new(high))
     }
 }


### PR DESCRIPTION
Propagate span information from the input AST to the Output MIR CFG data.

This span information will be used for both error messages and for Thorn insight tools.