### PR TITLE
T73 mir func args

### DIFF
--- a/src/compiler/mir/ir.rs
+++ b/src/compiler/mir/ir.rs
@@ -276,7 +276,7 @@ pub struct ArgDecl {
 }
 
 impl ArgDecl {
-    pub fn new(name: StringId, ty: &Type, span: Span) -> ArgDecl {
+    fn new(name: StringId, ty: &Type, span: Span) -> ArgDecl {
         ArgDecl {
             name,
             ty: ty.clone(),

--- a/src/compiler/mir/ir.rs
+++ b/src/compiler/mir/ir.rs
@@ -20,6 +20,8 @@ pub struct Procedure {
     blocks: Vec<BasicBlock>,
     /// The return type of this function
     ret_ty: Type,
+    /// The argument set for the function
+    args: Vec<ArgDecl>,
     /// The set of all user declared variables from within this function
     vars: Vec<VarDecl>,
     /// The set of all temporary variables created by the MIR compiler
@@ -35,6 +37,7 @@ impl Procedure {
         Procedure {
             blocks: vec![],
             ret_ty: ret_ty.clone(),
+            args: vec![],
             vars: vec![],
             temps: vec![],
             span,
@@ -46,11 +49,15 @@ impl Procedure {
     }
 
     /// Add an argument to this procedure
-    pub fn add_arg(&mut self, name: StringId, ty: &Type, span: Span) -> VarId {
-        let vd = VarDecl::new(name, false, ty, ScopeId::new(ROOT_SCOPE), span);
-        self.vars.push(vd);
-        let id = self.vars.len() - 1;
-        VarId::new(id)
+    pub fn add_arg(&mut self, name: StringId, ty: &Type, span: Span) -> ArgId {
+        // Add the given argument to the set of variables
+        self.add_var(name, false, ty, ScopeId::new(0), span);
+
+        // Add the argument to the argument set of the function
+        let ad = ArgDecl::new(name, ty, span);
+        self.args.push(ad);
+        let id = self.args.len() - 1;
+        ArgId::new(id)
     }
 
     /// Get a [`BasicBlock`] for this procedure
@@ -128,6 +135,20 @@ impl Procedure {
 impl Display for Procedure {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_fmt(format_args!("fn () -> {:?}:\n", self.ret_ty))?;
+
+        // Print the arguments
+        f.write_str("Arguments: \n")?;
+
+        // Print out the variables
+        for idx in 0..self.args.len() {
+            f.write_str("arg ")?;
+
+            f.write_fmt(format_args!(
+                "{}: {:?} // {} {}\n",
+                idx, self.args[idx].ty, self.args[idx].name, self.args[idx].span
+            ))?
+        }
+        f.write_str("\n")?;
 
         // Print out the stack: vars and temps
         f.write_str("Stack:\n")?;
@@ -239,6 +260,37 @@ impl ScopeId {
 
     pub fn index(&self) -> usize {
         self.0
+    }
+}
+
+/// An argument for a function.  These are always immutable and are always
+/// in the root scope: therefore, there is no scope or mutable property.
+#[derive(Debug, PartialEq, Clone)]
+pub struct ArgDecl {
+    /// Name of this variable
+    name: StringId,
+    /// The type of this variable
+    ty: Type,
+    /// The span of code where this variable was declared
+    span: Span,
+}
+
+impl ArgDecl {
+    pub fn new(name: StringId, ty: &Type, span: Span) -> ArgDecl {
+        ArgDecl {
+            name,
+            ty: ty.clone(),
+            span,
+        }
+    }
+}
+
+/// Unique identifier for an argument within the MIR of a function
+pub struct ArgId(u32);
+
+impl ArgId {
+    fn new(id: usize) -> ArgId {
+        ArgId(id as u32)
     }
 }
 

--- a/src/compiler/mir/ir.rs
+++ b/src/compiler/mir/ir.rs
@@ -20,7 +20,7 @@ pub struct Procedure {
     blocks: Vec<BasicBlock>,
     /// The return type of this function
     ret_ty: Type,
-    /// The argument set for the function
+    /// The argument list for the function
     args: Vec<ArgDecl>,
     /// The set of all user declared variables from within this function
     vars: Vec<VarDecl>,

--- a/src/compiler/mir/test.rs
+++ b/src/compiler/mir/test.rs
@@ -110,6 +110,25 @@ pub mod tests {
     }
 
     #[test]
+    fn print_mir_for_struct_field() {
+        let text = "
+        fn test(s: i64) -> i64 {
+            return s;
+        }
+
+        struct S {
+            a: i64,
+        }
+        ";
+        let mut table = StringTable::new();
+        let module = compile(text, &mut table);
+        let mirs = transform::module_transform(&module);
+        for mir in mirs {
+            println!("{}", mir);
+        }
+    }
+
+    #[test]
     fn array_expression() {
         let text = "
         fn test() -> i64 {

--- a/src/compiler/mir/transform.rs
+++ b/src/compiler/mir/transform.rs
@@ -138,6 +138,12 @@ impl MirBuilder {
         Operand::Constant(Constant::Null)
     }
 
+    /// Add an argument to the signature of a function. Arguments are also added to the
+    /// set of variables.
+    fn arg(&mut self, name: StringId, ty: &Type, span: Span) -> ArgId {
+        self.proc.add_arg(name, ty, span)
+    }
+
     /// Add a new user declared variable to this function's stack
     fn var(&mut self, name: StringId, mutable: bool, ty: &Type, span: Span) -> VarId {
         self.proc.add_var(name, mutable, ty, ScopeId::new(0), span)
@@ -322,6 +328,12 @@ impl FuncTransformer {
 
     pub fn transform(mut self, func: &RoutineDef<SemanticContext>) -> Procedure {
         self.mir.proc.set_span(func.context.span());
+
+        // Add the parameters of the function to the set of variables
+        func.params.iter().for_each(|p| {
+            self.mir
+                .arg(p.name, p.context().ty(), p.context().span());
+        });
 
         // Create a new MIR Procedure
         // Create a BasicBlock for the function


### PR DESCRIPTION
Store the set of arguments of a function to a Argument list, for use in argument checking operations, and to the set of variables that can be accessed within the function.

All arguments are immutable.