### PR TITLE
MIR: Split Builder from Transformer

### DIFF
--- a/src/compiler/mir/builder.rs
+++ b/src/compiler/mir/builder.rs
@@ -1,0 +1,335 @@
+use log::debug;
+
+use crate::{compiler::{ast::{Type, StructDef}, semantics::semanticnode::SemanticContext, Span}, StringId};
+
+use super::{typetable::*, ir::*};
+
+/// Manages all of the Types and Functions which exist within a single project
+pub struct MirProject {
+    types: TypeTable,
+}
+
+impl MirProject {
+    pub fn new() -> MirProject {
+        MirProject {
+            types: TypeTable::new(),
+        }
+    }
+
+    /// Searches the [`TypeTable`] for the [`TypeId`] of the given
+    /// [`Type`].
+    pub fn find_type(&self, ty: &Type) -> Option<TypeId> {
+        self.types.find(ty)
+    }
+
+    pub fn get_type(&self, ty: TypeId) -> &MirTypeDef {
+        self.types.get(ty)
+    }
+
+    /// Adds a new Structure definition to the [`MirProject`].
+    pub fn add_struct_def(
+        &mut self,
+        sd: &StructDef<SemanticContext>,
+    ) -> Result<(), TypeTableError> {
+        self.types.add_struct_def(sd)?;
+        Ok(())
+    }
+}
+
+/// Provides a Builder interface for constructing the MIR CFG representation of a
+/// routine. This will keep track of the current [`BasicBlock`] and make sure that
+/// MIR operations are applied to that [`BasicBlock`]. This also provides a simplfied
+/// interface for constructing the MIR operands, operations, and statements, to
+/// simplify the code that traverses input ASTs and transforms them into MIR.
+pub struct MirProcedureBuilder {
+    proc: Procedure,
+    current_bb: Option<BasicBlockId>,
+}
+
+impl MirProcedureBuilder {
+    /// Creates a new [`MirBuilder`], which is used to construct the MIR representation
+    /// of a function.
+    pub fn new() -> MirProcedureBuilder {
+        MirProcedureBuilder {
+            proc: Procedure::new(&Type::Unit, Span::zero()),
+            current_bb: None,
+        }
+    }
+
+    /// Finalizes the construction of a procedure and returns the MIR Procedure value.
+    pub fn complete(self) -> Procedure {
+        self.proc
+    }
+
+    /// Sets the span of input source code that this [`Procedure`] will represent.
+    pub fn set_span(&mut self, span: Span) {
+        self.proc.set_span(span)
+    }
+
+    /// Add a new [`BasicBlock`] to this function.
+    pub fn new_bb(&mut self) -> BasicBlockId {
+        self.proc.new_bb()
+    }
+
+    /// Change the active [`BasicBlock`]. After this call, all instructions added
+    /// to the function will be appended to the [`BasicBlock`] specified by `bb`.
+    pub fn set_bb(&mut self, bb: BasicBlockId) {
+        self.current_bb = Some(bb)
+    }
+
+    pub fn find_var(&self, name: StringId) -> Option<VarId> {
+        self.proc.find_var(name)
+    }
+
+    /// Create an [`i8`] constant
+    pub fn const_i8(&mut self, i: i8) -> Operand {
+        Operand::Constant(Constant::I8(i))
+    }
+
+    /// Create an [`i16`] constant
+    pub fn const_i16(&mut self, i: i16) -> Operand {
+        Operand::Constant(Constant::I16(i))
+    }
+
+    /// Create an [`i32`] constant
+    pub fn const_i32(&mut self, i: i32) -> Operand {
+        Operand::Constant(Constant::I32(i))
+    }
+
+    /// Create an [`i64`] constant
+    pub fn const_i64(&mut self, i: i64) -> Operand {
+        Operand::Constant(Constant::I64(i))
+    }
+
+    /// Create a [`u8`] constant
+    pub fn const_u8(&mut self, i: u8) -> Operand {
+        Operand::Constant(Constant::U8(i))
+    }
+
+    /// Create a [`u16`] constant
+    pub fn const_u16(&mut self, i: u16) -> Operand {
+        Operand::Constant(Constant::U16(i))
+    }
+
+    /// Create a [`u32`] constant
+    pub fn const_u32(&mut self, i: u32) -> Operand {
+        Operand::Constant(Constant::U32(i))
+    }
+
+    /// Create a [`u64`] constant
+    pub fn const_u64(&mut self, i: u64) -> Operand {
+        Operand::Constant(Constant::U64(i))
+    }
+
+    /// Create an [`f64`] constant
+    pub fn const_f64(&mut self, f: f64) -> Operand {
+        Operand::Constant(Constant::F64(f))
+    }
+
+    /// Create a [`bool`] constant
+    pub fn const_bool(&mut self, b: bool) -> Operand {
+        Operand::Constant(Constant::Bool(b))
+    }
+
+    /// Create a reference to a string literal
+    pub fn const_stringliteral(&mut self, s: StringId) -> Operand {
+        Operand::Constant(Constant::StringLiteral(s))
+    }
+
+    /// Create a `null` value
+    pub fn const_null(&mut self) -> Operand {
+        Operand::Constant(Constant::Null)
+    }
+
+    /// Add an argument to the signature of a function. Arguments are also added to the
+    /// set of variables.
+    pub fn arg(&mut self, name: StringId, ty: &Type, span: Span) -> ArgId {
+        self.proc.add_arg(name, ty, span)
+    }
+
+    /// Add a new user declared variable to this function's stack
+    pub fn var(&mut self, name: StringId, mutable: bool, ty: &Type, span: Span) -> VarId {
+        self.proc.add_var(name, mutable, ty, ScopeId::new(0), span)
+    }
+
+    /// Add a new temporary variable to this function's stack
+    pub fn temp(&mut self, ty: &Type, span: Span) -> TempId {
+        self.proc.add_temp(ty, span)
+    }
+
+    /// Create a new temporary variable and store the [`RValue`] in it.
+    pub fn temp_store(&mut self, rv: RValue, ty: &Type, span: Span) -> Operand {
+        let tv = LValue::Temp(self.temp(ty, span));
+        debug!("Temp store: {:?} := {:?}", tv, rv);
+
+        self.store(tv.clone(), rv, span);
+
+        Operand::LValue(tv)
+    }
+
+    /// Store the given [`RValue`] in the location specified by the given
+    /// [`LValue`].
+    pub fn store(&mut self, lv: LValue, rv: RValue, span: Span) {
+        debug!("Store: {:?} := {:?}", lv, rv);
+
+        let cid = self.current_bb.unwrap();
+        let bb = self.proc.get_bb_mut(cid);
+        bb.add_stm(super::ir::Statement::new(
+            StatementKind::Assign(lv, rv),
+            span,
+        ));
+    }
+
+    /// Will construct an [`LValue`] whose location is the specified `field` in a given
+    /// strucure type. This expects `ty` to be a [`MirTypeDef::Structure`].
+    pub fn member_access(&mut self, base: LValue, def: &MirStructDef, field: StringId) -> LValue {
+        debug!("Member Access: {:?}.{:?}", base, def);
+
+        let (field_id, field_mir) = def
+            .find_field(field)
+            .expect("Could not find field in structure");
+
+        LValue::Access(Box::new(base), Accessor::Field(field_id, field_mir.ty))
+    }
+
+    pub fn array_at(&mut self, array: LValue, index: Operand) -> LValue {
+        debug!("Array At: {:?}[{:?}]", array, index);
+
+        LValue::Access(Box::new(array), Accessor::Index(Box::new(index)))
+    }
+
+    /// Add a boolean not to the current [`BasicBlock`].
+    pub fn not(&mut self, right: Operand) -> RValue {
+        debug!("Not: {:?}", right);
+
+        RValue::UnOp(UnOp::Not, right)
+    }
+
+    /// Add a negate to the current [`BasicBlock`].
+    pub fn negate(&mut self, right: Operand) -> RValue {
+        debug!("Negate: {:?}", right);
+        RValue::UnOp(UnOp::Negate, right)
+    }
+
+    /// Add an addition operation to the current [`BasicBlock`].
+    pub fn add(&mut self, left: Operand, right: Operand) -> RValue {
+        debug!("Add: {:?}, {:?}", left, right);
+        RValue::BinOp(BinOp::Add, left, right)
+    }
+
+    /// Add a subtraction operation to the current [`BasicBlock`].
+    pub fn sub(&mut self, left: Operand, right: Operand) -> RValue {
+        debug!("Sub: {:?}, {:?}", left, right);
+        RValue::BinOp(BinOp::Sub, left, right)
+    }
+
+    /// Add a multiply operation to the current [`BasicBlock`].
+    pub fn mul(&mut self, left: Operand, right: Operand) -> RValue {
+        debug!("Mul: {:?}, {:?}", left, right);
+        RValue::BinOp(BinOp::Mul, left, right)
+    }
+
+    /// Add a divide operation to the current [`BasicBlock`].
+    pub fn div(&mut self, left: Operand, right: Operand) -> RValue {
+        debug!("Div: {:?}, {:?}", left, right);
+        RValue::BinOp(BinOp::Div, left, right)
+    }
+
+    /// Add a bitwise and operation to the current [`BasicBlock`].
+    pub fn bitwise_and(&mut self, left: Operand, right: Operand) -> RValue {
+        debug!("And: {:?}, {:?}", left, right);
+        RValue::BinOp(BinOp::And, left, right)
+    }
+
+    /// Add a bitwise and operation to the current [`BasicBlock`].
+    pub fn bitwise_or(&mut self, left: Operand, right: Operand) -> RValue {
+        debug!("Or: {:?}, {:?}", left, right);
+        RValue::BinOp(BinOp::Or, left, right)
+    }
+
+    /// Add an equality test operation to the current [`BasicBlock`].
+    pub fn eq(&mut self, left: Operand, right: Operand) -> RValue {
+        debug!("Eq: {:?}, {:?}", left, right);
+        RValue::BinOp(BinOp::Eq, left, right)
+    }
+
+    /// Add a not equal test operation to the current [`BasicBlock`].
+    pub fn neq(&mut self, left: Operand, right: Operand) -> RValue {
+        debug!("Neq: {:?}, {:?}", left, right);
+        RValue::BinOp(BinOp::Ne, left, right)
+    }
+
+    /// Add a less than test operation to the current [`BasicBlock`].
+    pub fn lt(&mut self, left: Operand, right: Operand) -> RValue {
+        debug!("Less Than");
+        debug!("Add: {:?}, {:?}", left, right);
+        RValue::BinOp(BinOp::Lt, left, right)
+    }
+
+    /// Add a less than or equal to test operation to the current [`BasicBlock`].
+    pub fn le(&mut self, left: Operand, right: Operand) -> RValue {
+        debug!("Less or Equal: {:?}, {:?}", left, right);
+        RValue::BinOp(BinOp::Le, left, right)
+    }
+
+    /// Add a greater than test operation to the current [`BasicBlock`].
+    pub fn gt(&mut self, left: Operand, right: Operand) -> RValue {
+        debug!("Greater: {:?}, {:?}", left, right);
+        RValue::BinOp(BinOp::Gt, left, right)
+    }
+
+    /// Add a greater than or equal to test operation to the current [`BasicBlock`].
+    pub fn ge(&mut self, left: Operand, right: Operand) -> RValue {
+        debug!("Greater or Equal: {:?}, {:?}", left, right);
+        RValue::BinOp(BinOp::Ge, left, right)
+    }
+
+    /// Add a raw pointer offset operation to the current [`BasicBlock`].
+    pub fn offset(&mut self, left: Operand, right: Operand) -> RValue {
+        debug!("Pointer Offset: {:?}, {:?}", left, right);
+        todo!()
+    }
+
+    /// Terminates by returning to the caller function
+    pub fn term_return(&mut self, span: Span) {
+        debug!("Terminator: Return");
+        let cid = self.current_bb.unwrap();
+        let bb = self.proc.get_bb_mut(cid);
+        bb.set_terminator(Terminator::new(TerminatorKind::Return, span));
+    }
+
+    /// Terminates by going to the destination basic block
+    pub fn term_goto(&mut self, target: BasicBlockId, span: Span) {
+        debug!("Goto: {:?}", target);
+        let cid = self.current_bb.unwrap();
+        let bb = self.proc.get_bb_mut(cid);
+        bb.set_terminator(Terminator::new(TerminatorKind::GoTo { target }, span))
+    }
+
+    /// Terminates with a conditional go to
+    pub fn term_cond_goto(
+        &mut self,
+        cond: Operand,
+        then_bb: BasicBlockId,
+        else_bb: BasicBlockId,
+        span: Span,
+    ) {
+        debug!("If {:?} then {:?} else {:?}", cond, then_bb, else_bb);
+        let cid = self.current_bb.unwrap();
+        let bb = self.proc.get_bb_mut(cid);
+        bb.set_terminator(Terminator::new(
+            TerminatorKind::CondGoTo {
+                cond,
+                tru: then_bb,
+                fls: else_bb,
+            },
+            span,
+        ));
+    }
+
+    /// Terminates by calling the given function
+    pub fn term_call(&mut self) {
+        debug!("Call");
+        todo!()
+    }
+}

--- a/src/compiler/mir/mod.rs
+++ b/src/compiler/mir/mod.rs
@@ -18,9 +18,11 @@ use super::Span;
 
 mod ir;
 mod test;
-pub mod transform;
+mod builder;
 mod typetable;
 mod typetable_test;
+
+pub mod transform;
 
 pub struct Module {
     funcs: Vec<Procedure>,

--- a/src/compiler/mir/test.rs
+++ b/src/compiler/mir/test.rs
@@ -7,7 +7,7 @@ pub mod tests {
             lexer::{tokens::Token, LexerError},
             mir::{
                 ir::*,
-                transform::{self, MirProject},
+                transform, builder::MirProject,
             },
             parser::Parser,
             semantics::semanticnode::SemanticContext,
@@ -45,6 +45,7 @@ pub mod tests {
     /// validation. They are to be used for visual validation of a MIR
     /// and to aid in writing the actual unit tests.
     mod print {
+
         use super::*;
 
         #[test]
@@ -622,7 +623,7 @@ pub mod tests {
             ) => {
                 assert_eq!(lv, rv);
 
-                let expected_ty = project.get_type(&Type::I64).unwrap();
+                let expected_ty = project.find_type(&Type::I64).unwrap();
                 assert_eq!(*lfty, expected_ty);
                 assert_eq!(*rfty, expected_ty);
 
@@ -670,7 +671,7 @@ pub mod tests {
                     Operand::LValue(LValue::Access(rv, Accessor::Field(rfid, rfty))),
                 ),
             ) => {
-                let expected_ty = project.get_type(&Type::I64).unwrap();
+                let expected_ty = project.find_type(&Type::I64).unwrap();
 
                 let lv = if let LValue::Access(lv, Accessor::Field(fid, _)) = lv.as_ref() {
                     assert_eq!(u32::from(*fid), 0);

--- a/src/compiler/mir/transform.rs
+++ b/src/compiler/mir/transform.rs
@@ -13,7 +13,7 @@ use crate::{
     compiler::{
         ast::{
             BinaryOperator, Bind, Context, Expression, Item, Module, Node, Return, RoutineDef,
-            Statement, StructDef, Type, UnaryOperator,
+            Statement, Type, UnaryOperator,
         },
         semantics::semanticnode::SemanticContext,
         source::Offset,
@@ -22,7 +22,7 @@ use crate::{
     StringId,
 };
 
-use super::{ir::*, typetable::*};
+use super::{ir::*, typetable::*, builder::{MirProject, MirProcedureBuilder}};
 
 pub fn module_transform(
     module: &Module<SemanticContext>,
@@ -53,322 +53,6 @@ pub fn module_transform(
     mirs
 }
 
-/// Manages all of the Types and Functions which exist within a single project
-pub struct MirProject {
-    types: TypeTable,
-}
-
-impl MirProject {
-    pub fn new() -> MirProject {
-        MirProject {
-            types: TypeTable::new(),
-        }
-    }
-
-    /// Searches the [`TypeTable`] for the [`TypeId`] of the given
-    /// [`Type`].
-    pub fn get_type(&self, ty: &Type) -> Option<TypeId> {
-        self.types.find(ty)
-    }
-
-    /// Adds a new Structure definition to the [`MirProject`].
-    pub fn add_struct_def(
-        &mut self,
-        sd: &StructDef<SemanticContext>,
-    ) -> Result<(), TypeTableError> {
-        self.types.add_struct_def(sd)?;
-        Ok(())
-    }
-}
-
-/// Provides a Builder interface for constructing the MIR CFG representation of a
-/// routine. This will keep track of the current [`BasicBlock`] and make sure that
-/// MIR operations are applied to that [`BasicBlock`]. This also provides a simplfied
-/// interface for constructing the MIR operands, operations, and statements, to
-/// simplify the code that traverses input ASTs and transforms them into MIR.
-struct MirProcedureBuilder {
-    proc: Procedure,
-    current_bb: Option<BasicBlockId>,
-}
-
-impl MirProcedureBuilder {
-    /// Creates a new [`MirBuilder`], which is used to construct the MIR representation
-    /// of a function.
-    pub fn new() -> MirProcedureBuilder {
-        MirProcedureBuilder {
-            proc: Procedure::new(&Type::Unit, Span::zero()),
-            current_bb: None,
-        }
-    }
-
-    /// Add a new [`BasicBlock`] to this function.
-    fn new_bb(&mut self) -> BasicBlockId {
-        self.proc.new_bb()
-    }
-
-    /// Change the active [`BasicBlock`]. After this call, all instructions added
-    /// to the function will be appended to the [`BasicBlock`] specified by `bb`.
-    fn set_bb(&mut self, bb: BasicBlockId) {
-        self.current_bb = Some(bb)
-    }
-
-    fn find_var(&self, name: StringId) -> Option<VarId> {
-        self.proc.find_var(name)
-    }
-
-    /// Create an [`i8`] constant
-    fn const_i8(&mut self, i: i8) -> Operand {
-        Operand::Constant(Constant::I8(i))
-    }
-
-    /// Create an [`i16`] constant
-    fn const_i16(&mut self, i: i16) -> Operand {
-        Operand::Constant(Constant::I16(i))
-    }
-
-    /// Create an [`i32`] constant
-    fn const_i32(&mut self, i: i32) -> Operand {
-        Operand::Constant(Constant::I32(i))
-    }
-
-    /// Create an [`i64`] constant
-    fn const_i64(&mut self, i: i64) -> Operand {
-        Operand::Constant(Constant::I64(i))
-    }
-
-    /// Create a [`u8`] constant
-    fn const_u8(&mut self, i: u8) -> Operand {
-        Operand::Constant(Constant::U8(i))
-    }
-
-    /// Create a [`u16`] constant
-    fn const_u16(&mut self, i: u16) -> Operand {
-        Operand::Constant(Constant::U16(i))
-    }
-
-    /// Create a [`u32`] constant
-    fn const_u32(&mut self, i: u32) -> Operand {
-        Operand::Constant(Constant::U32(i))
-    }
-
-    /// Create a [`u64`] constant
-    fn const_u64(&mut self, i: u64) -> Operand {
-        Operand::Constant(Constant::U64(i))
-    }
-
-    /// Create an [`f64`] constant
-    fn const_f64(&mut self, f: f64) -> Operand {
-        Operand::Constant(Constant::F64(f))
-    }
-
-    /// Create a [`bool`] constant
-    fn const_bool(&mut self, b: bool) -> Operand {
-        Operand::Constant(Constant::Bool(b))
-    }
-
-    /// Create a reference to a string literal
-    fn const_stringliteral(&mut self, s: StringId) -> Operand {
-        Operand::Constant(Constant::StringLiteral(s))
-    }
-
-    /// Create a `null` value
-    fn const_null(&mut self) -> Operand {
-        Operand::Constant(Constant::Null)
-    }
-
-    /// Add an argument to the signature of a function. Arguments are also added to the
-    /// set of variables.
-    fn arg(&mut self, name: StringId, ty: &Type, span: Span) -> ArgId {
-        self.proc.add_arg(name, ty, span)
-    }
-
-    /// Add a new user declared variable to this function's stack
-    fn var(&mut self, name: StringId, mutable: bool, ty: &Type, span: Span) -> VarId {
-        self.proc.add_var(name, mutable, ty, ScopeId::new(0), span)
-    }
-
-    /// Add a new temporary variable to this function's stack
-    fn temp(&mut self, ty: &Type, span: Span) -> TempId {
-        self.proc.add_temp(ty, span)
-    }
-
-    /// Create a new temporary variable and store the [`RValue`] in it.
-    fn temp_store(&mut self, rv: RValue, ty: &Type, span: Span) -> Operand {
-        let tv = LValue::Temp(self.temp(ty, span));
-        debug!("Temp store: {:?} := {:?}", tv, rv);
-
-        self.store(tv.clone(), rv, span);
-
-        Operand::LValue(tv)
-    }
-
-    /// Store the given [`RValue`] in the location specified by the given
-    /// [`LValue`].
-    fn store(&mut self, lv: LValue, rv: RValue, span: Span) {
-        debug!("Store: {:?} := {:?}", lv, rv);
-
-        let cid = self.current_bb.unwrap();
-        let bb = self.proc.get_bb_mut(cid);
-        bb.add_stm(super::ir::Statement::new(
-            StatementKind::Assign(lv, rv),
-            span,
-        ));
-    }
-
-    /// Will construct an [`LValue`] whose location is the specified `field` in a given
-    /// strucure type. This expects `ty` to be a [`MirTypeDef::Structure`].
-    fn member_access(&mut self, base: LValue, def: &MirStructDef, field: StringId) -> LValue {
-        debug!("Member Access: {:?}.{:?}", base, def);
-
-        let (field_id, field_mir) = def
-            .find_field(field)
-            .expect("Could not find field in structure");
-
-        LValue::Access(Box::new(base), Accessor::Field(field_id, field_mir.ty))
-    }
-
-    fn array_at(&mut self, array: LValue, index: Operand) -> LValue {
-        debug!("Array At: {:?}[{:?}]", array, index);
-
-        LValue::Access(Box::new(array), Accessor::Index(Box::new(index)))
-    }
-
-    /// Add a boolean not to the current [`BasicBlock`].
-    fn not(&mut self, right: Operand) -> RValue {
-        debug!("Not: {:?}", right);
-
-        RValue::UnOp(UnOp::Not, right)
-    }
-
-    /// Add a negate to the current [`BasicBlock`].
-    fn negate(&mut self, right: Operand) -> RValue {
-        debug!("Negate: {:?}", right);
-        RValue::UnOp(UnOp::Negate, right)
-    }
-
-    /// Add an addition operation to the current [`BasicBlock`].
-    fn add(&mut self, left: Operand, right: Operand) -> RValue {
-        debug!("Add: {:?}, {:?}", left, right);
-        RValue::BinOp(BinOp::Add, left, right)
-    }
-
-    /// Add a subtraction operation to the current [`BasicBlock`].
-    fn sub(&mut self, left: Operand, right: Operand) -> RValue {
-        debug!("Sub: {:?}, {:?}", left, right);
-        RValue::BinOp(BinOp::Sub, left, right)
-    }
-
-    /// Add a multiply operation to the current [`BasicBlock`].
-    fn mul(&mut self, left: Operand, right: Operand) -> RValue {
-        debug!("Mul: {:?}, {:?}", left, right);
-        RValue::BinOp(BinOp::Mul, left, right)
-    }
-
-    /// Add a divide operation to the current [`BasicBlock`].
-    fn div(&mut self, left: Operand, right: Operand) -> RValue {
-        debug!("Div: {:?}, {:?}", left, right);
-        RValue::BinOp(BinOp::Div, left, right)
-    }
-
-    /// Add a bitwise and operation to the current [`BasicBlock`].
-    fn bitwise_and(&mut self, left: Operand, right: Operand) -> RValue {
-        debug!("And: {:?}, {:?}", left, right);
-        RValue::BinOp(BinOp::And, left, right)
-    }
-
-    /// Add a bitwise and operation to the current [`BasicBlock`].
-    fn bitwise_or(&mut self, left: Operand, right: Operand) -> RValue {
-        debug!("Or: {:?}, {:?}", left, right);
-        RValue::BinOp(BinOp::Or, left, right)
-    }
-
-    /// Add an equality test operation to the current [`BasicBlock`].
-    fn eq(&mut self, left: Operand, right: Operand) -> RValue {
-        debug!("Eq: {:?}, {:?}", left, right);
-        RValue::BinOp(BinOp::Eq, left, right)
-    }
-
-    /// Add a not equal test operation to the current [`BasicBlock`].
-    fn neq(&mut self, left: Operand, right: Operand) -> RValue {
-        debug!("Neq: {:?}, {:?}", left, right);
-        RValue::BinOp(BinOp::Ne, left, right)
-    }
-
-    /// Add a less than test operation to the current [`BasicBlock`].
-    fn lt(&mut self, left: Operand, right: Operand) -> RValue {
-        debug!("Less Than");
-        debug!("Add: {:?}, {:?}", left, right);
-        RValue::BinOp(BinOp::Lt, left, right)
-    }
-
-    /// Add a less than or equal to test operation to the current [`BasicBlock`].
-    fn le(&mut self, left: Operand, right: Operand) -> RValue {
-        debug!("Less or Equal: {:?}, {:?}", left, right);
-        RValue::BinOp(BinOp::Le, left, right)
-    }
-
-    /// Add a greater than test operation to the current [`BasicBlock`].
-    fn gt(&mut self, left: Operand, right: Operand) -> RValue {
-        debug!("Greater: {:?}, {:?}", left, right);
-        RValue::BinOp(BinOp::Gt, left, right)
-    }
-
-    /// Add a greater than or equal to test operation to the current [`BasicBlock`].
-    fn ge(&mut self, left: Operand, right: Operand) -> RValue {
-        debug!("Greater or Equal: {:?}, {:?}", left, right);
-        RValue::BinOp(BinOp::Ge, left, right)
-    }
-
-    /// Add a raw pointer offset operation to the current [`BasicBlock`].
-    fn offset(&mut self, left: Operand, right: Operand) -> RValue {
-        debug!("Pointer Offset: {:?}, {:?}", left, right);
-        todo!()
-    }
-
-    /// Terminates by returning to the caller function
-    fn term_return(&mut self, span: Span) {
-        debug!("Terminator: Return");
-        let cid = self.current_bb.unwrap();
-        let bb = self.proc.get_bb_mut(cid);
-        bb.set_terminator(Terminator::new(TerminatorKind::Return, span));
-    }
-
-    /// Terminates by going to the destination basic block
-    fn term_goto(&mut self, target: BasicBlockId, span: Span) {
-        debug!("Goto: {:?}", target);
-        let cid = self.current_bb.unwrap();
-        let bb = self.proc.get_bb_mut(cid);
-        bb.set_terminator(Terminator::new(TerminatorKind::GoTo { target }, span))
-    }
-
-    /// Terminates with a conditional go to
-    fn term_cond_goto(
-        &mut self,
-        cond: Operand,
-        then_bb: BasicBlockId,
-        else_bb: BasicBlockId,
-        span: Span,
-    ) {
-        debug!("If {:?} then {:?} else {:?}", cond, then_bb, else_bb);
-        let cid = self.current_bb.unwrap();
-        let bb = self.proc.get_bb_mut(cid);
-        bb.set_terminator(Terminator::new(
-            TerminatorKind::CondGoTo {
-                cond,
-                tru: then_bb,
-                fls: else_bb,
-            },
-            span,
-        ));
-    }
-
-    /// Terminates by calling the given function
-    fn term_call(&mut self) {
-        debug!("Call");
-        todo!()
-    }
-}
-
 /// Transform a single function to the MIR form
 struct FuncTransformer<'a> {
     project: &'a MirProject,
@@ -384,7 +68,7 @@ impl<'a> FuncTransformer<'a> {
     }
 
     pub fn transform(mut self, func: &RoutineDef<SemanticContext>) -> Procedure {
-        self.mir.proc.set_span(func.context.span());
+        self.mir.set_span(func.context.span());
 
         // Add the parameters of the function to the set of variables
         func.params.iter().for_each(|p| {
@@ -401,7 +85,7 @@ impl<'a> FuncTransformer<'a> {
 
         // Add the return from function as the terminator for the final basic block of the function
         self.mir.term_return(span_end(func.context.span()));
-        self.mir.proc
+        self.mir.complete()
     }
 
     fn statement(&mut self, stm: &Statement<SemanticContext>) {
@@ -522,11 +206,11 @@ impl<'a> FuncTransformer<'a> {
         let ty = base.context().ty();
         let mir_ty = self
             .project
-            .get_type(ty)
+            .find_type(ty)
             .expect("Could not find given type in the type table");
 
         // Extract the Structure Definition from the type
-        let mir_ty = self.project.types.get(mir_ty);
+        let mir_ty = self.project.get_type(mir_ty);
         let def = if let MirTypeDef::Structure { def, .. } = mir_ty {
             def
         } else {


### PR DESCRIPTION
To help with readability and organization the `transformer.rs` file has been split into `transformer.rs` and `builder.rs`. The latter deals with Builder types that are used to construct actual MIR values.  The former deals with the actual traversal of the AST and uses the Builders to convert AST nodes and subtrees into MIR representations.