### PR TITLE
T56 mir sizeof

### DIFF
--- a/src/compiler/mir/builder.rs
+++ b/src/compiler/mir/builder.rs
@@ -134,6 +134,10 @@ impl MirProcedureBuilder {
         Operand::Constant(Constant::Null)
     }
 
+    pub fn size_of(&self, ty: TypeId) -> Operand {
+        Operand::Constant(Constant::SizeOf(ty))
+    }
+
     /// Add an argument to the signature of a function. Arguments are also added to the
     /// set of variables.
     pub fn arg(&mut self, name: StringId, ty: TypeId, span: Span) -> ArgId {

--- a/src/compiler/mir/builder.rs
+++ b/src/compiler/mir/builder.rs
@@ -134,6 +134,7 @@ impl MirProcedureBuilder {
         Operand::Constant(Constant::Null)
     }
 
+    /// Create a constant value of the size of the given type
     pub fn size_of(&self, ty: TypeId) -> Operand {
         Operand::Constant(Constant::SizeOf(ty))
     }

--- a/src/compiler/mir/ir.rs
+++ b/src/compiler/mir/ir.rs
@@ -614,9 +614,6 @@ pub enum RValue {
 
     /// Getting the address of a variable in memory.
     AddressOf(LValue),
-
-    /// Gets the size of a specific type
-    SizeOf(TypeId),
 }
 
 impl Display for RValue {
@@ -627,7 +624,6 @@ impl Display for RValue {
             RValue::UnOp(op, o) => format!("{}({})", op, o),
             RValue::Cast(v, ty) => format!("{} as {:?}", v, ty),
             RValue::AddressOf(o) => format!("AddressOf({})", o),
-            RValue::SizeOf(ty) => format!("size_of({:?})", ty),
         };
         f.write_str(&text)
     }
@@ -677,6 +673,7 @@ pub enum Constant {
     Bool(bool),
     StringLiteral(StringId),
     Null,
+    SizeOf(TypeId),
 }
 
 impl Display for Constant {
@@ -695,6 +692,7 @@ impl Display for Constant {
             Constant::F64(v) => f.write_fmt(format_args!("{}f64", v)),
             Constant::Bool(b) => f.write_fmt(format_args!("{}", b)),
             Constant::StringLiteral(sid) => f.write_fmt(format_args!("{}", sid)),
+            Constant::SizeOf(ty) => f.write_fmt(format_args!("size_of({:?})", ty)),
         }
     }
 }

--- a/src/compiler/mir/ir.rs
+++ b/src/compiler/mir/ir.rs
@@ -614,6 +614,9 @@ pub enum RValue {
 
     /// Getting the address of a variable in memory.
     AddressOf(LValue),
+
+    /// Gets the size of a specific type
+    SizeOf(TypeId),
 }
 
 impl Display for RValue {
@@ -622,8 +625,9 @@ impl Display for RValue {
             RValue::Use(o) => format!("Use({})", o),
             RValue::BinOp(op, l, r) => format!("{}({}, {})", op, l, r),
             RValue::UnOp(op, o) => format!("{}({})", op, o),
-            RValue::Cast(v, t) => format!("{} as {:?}", v, t),
+            RValue::Cast(v, ty) => format!("{} as {:?}", v, ty),
             RValue::AddressOf(o) => format!("AddressOf({})", o),
+            RValue::SizeOf(ty) => format!("size_of({:?})", ty),
         };
         f.write_str(&text)
     }

--- a/src/compiler/mir/transform/function.rs
+++ b/src/compiler/mir/transform/function.rs
@@ -191,7 +191,7 @@ impl<'a> FuncTransformer<'a> {
 
     fn size_of(&mut self, ctx: &SemanticContext, ty: &Type) -> Operand {
         let ty = self.project.find_type(ty).expect("Could not find type");
-        Operand::Constant(Constant::SizeOf(ty))
+        self.mir.size_of(ty)
     }
 
     fn stuct_expr(

--- a/src/compiler/mir/transform/function.rs
+++ b/src/compiler/mir/transform/function.rs
@@ -137,7 +137,7 @@ impl<'a> FuncTransformer<'a> {
                 self.mir.temp_store(rv, ty, ctx.span())
             }
             Expression::TypeCast(ctx, expr, target) => self.cast(ctx, expr, target),
-            Expression::SizeOf(_, _) => todo!(),
+            Expression::SizeOf(ctx, ty) => self.size_of(ctx, ty.as_ref()),
             Expression::MemberAccess(_, base, field) => self.member_access(base, *field),
             Expression::ArrayExpression(ctx, els, sz) => {
                 self.array_expr(ctx.ty(), els, *sz, ctx.span())
@@ -187,6 +187,11 @@ impl<'a> FuncTransformer<'a> {
             }
             Expression::Yield(_, _) => todo!(),
         }
+    }
+
+    fn size_of(&mut self, ctx: &SemanticContext, ty: &Type) -> Operand {
+        let ty = self.project.find_type(ty).expect("Could not find type");
+        Operand::Constant(Constant::SizeOf(ty))
     }
 
     fn stuct_expr(


### PR DESCRIPTION
Convert the `size_of` operation to a constant in the MIR. This is represented as a constant because the size of a type is determined during the LLVM to assembly compilation step and within the output assembly it will be a constant.

Representing this as a constant also simplifies the MIR output.

It also forces the MIR code and all subsequent operations to treat the size_of as an immutable constant, which it is.