### PR TITLE
T85 fix deref mir

### DIFF
--- a/src/compiler/mir/builder.rs
+++ b/src/compiler/mir/builder.rs
@@ -179,6 +179,7 @@ impl MirProcedureBuilder {
         ));
     }
 
+    /// Will construct an [`LValue`] whose location is the address stored in `right`.
     pub fn deref_rawpointer(&self, right: LValue) -> LValue {
         debug!("Deref Raw: {:?}", right);
         LValue::Access(Box::new(right), Accessor::Deref)

--- a/src/compiler/mir/builder.rs
+++ b/src/compiler/mir/builder.rs
@@ -179,6 +179,11 @@ impl MirProcedureBuilder {
         ));
     }
 
+    pub fn deref_rawpointer(&self, right: LValue) -> LValue {
+        debug!("Deref Raw: {:?}", right);
+        LValue::Access(Box::new(right), Accessor::Deref)
+    }
+
     /// Will construct an [`LValue`] whose location is the specified `field` in a given
     /// strucure type. This expects `ty` to be a [`MirTypeDef::Structure`].
     pub fn member_access(&self, base: LValue, def: &MirStructDef, field: StringId) -> LValue {
@@ -208,11 +213,6 @@ impl MirProcedureBuilder {
     pub fn negate(&self, right: Operand) -> RValue {
         debug!("Negate: {:?}", right);
         RValue::UnOp(UnOp::Negate, right)
-    }
-
-    pub fn deref_rawpointer(&self, right: Operand) -> RValue {
-        debug!("Deref Raw: {:?}", right);
-        RValue::UnOp(UnOp::DerefRawPointer, right)
     }
 
     /// Add an addition operation to the current [`BasicBlock`].

--- a/src/compiler/mir/ir.rs
+++ b/src/compiler/mir/ir.rs
@@ -834,8 +834,6 @@ pub enum UnOp {
     Negate,
     /// '!' bitwise not a primitive value
     Not,
-    /// '^' dereference a raw pointer
-    DerefRawPointer,
 }
 
 impl Display for UnOp {
@@ -843,7 +841,6 @@ impl Display for UnOp {
         let txt = match self {
             UnOp::Negate => "-",
             UnOp::Not => "!",
-            UnOp::DerefRawPointer => "^",
         };
         f.write_str(txt)
     }

--- a/src/compiler/mir/ir.rs
+++ b/src/compiler/mir/ir.rs
@@ -568,7 +568,10 @@ impl Display for LValue {
             LValue::Static(s) => format!("Static({})", s),
             LValue::Var(v) => format!("{}", v),
             LValue::Temp(t) => format!("{}", t),
-            LValue::Access(lv, acc) => format!("{}{}", lv, acc),
+            LValue::Access(lv, acc) => match acc {
+                Accessor::Deref => format!("^{}", lv),
+                _ => format!("{}{}", lv, acc),
+            },
             LValue::ReturnPointer => "ReturnPtr".into(),
         };
         f.write_str(&text)

--- a/src/compiler/mir/test.rs
+++ b/src/compiler/mir/test.rs
@@ -715,14 +715,17 @@ pub mod tests {
 
             let bb = mir.get_bb(BasicBlockId::new(0));
             let stm = bb.get_stm(0);
-            /*match stm.kind() {
+            match stm.kind() {
                 StatementKind::Assign(_, r) => {
                     assert_eq!(
                         *r,
-                        RValue::
+                        RValue::Use(Operand::LValue(LValue::Access(
+                            Box::new(LValue::Var(VarId::new(0))),
+                            Accessor::Deref
+                        )))
                     );
                 }
-            }*/
+            }
         }
     }
 

--- a/src/compiler/mir/test.rs
+++ b/src/compiler/mir/test.rs
@@ -221,6 +221,23 @@ pub mod tests {
             transform::transform(&module, &mut project).unwrap();
             println!("{}", project);
         }
+
+        #[test]
+        fn print_mir_for_deref() {
+            let text = "
+        fn test() -> i64 {
+            let mut x: i64 := 5;
+            let p: *mut i64 := @mut x;
+            mut ^p := 10;
+            return ^p;
+        }
+        ";
+            let mut table = StringTable::new();
+            let module = compile(text, &mut table);
+            let mut project = MirProject::new();
+            transform::transform(&module, &mut project).unwrap();
+            println!("{}", project);
+        }
     }
 
     #[test]
@@ -698,17 +715,14 @@ pub mod tests {
 
             let bb = mir.get_bb(BasicBlockId::new(0));
             let stm = bb.get_stm(0);
-            match stm.kind() {
+            /*match stm.kind() {
                 StatementKind::Assign(_, r) => {
                     assert_eq!(
                         *r,
-                        RValue::UnOp(
-                            UnOp::DerefRawPointer,
-                            Operand::LValue(LValue::Var(VarId::new(0)))
-                        )
+                        RValue::
                     );
                 }
-            }
+            }*/
         }
     }
 

--- a/src/compiler/mir/transform/function.rs
+++ b/src/compiler/mir/transform/function.rs
@@ -471,7 +471,13 @@ impl<'a> FuncTransformer<'a> {
                     panic!("AddressOf can only be applied to LValues")
                 }
             }
-            UnaryOperator::DerefRawPointer => self.mir.deref_rawpointer(right),
+            UnaryOperator::DerefRawPointer => {
+                if let Operand::LValue(lv) = right {
+                    RValue::Use(self.mir.deref_rawpointer(lv))
+                } else {
+                    panic!("Deref can only be applied to LValues")
+                }
+            }
         }
     }
 


### PR DESCRIPTION
The previous implementation of deref was not sufficient to properly cover the roles deref can take. Specifically, it only supported a deref access to happen on the right side of an assignment operator.

This fix has the MIR generator properly treat the deref expression results as addressable expressions.