### PR TITLE
T89 mir transform trait

### DIFF
--- a/src/compiler/mir/mod.rs
+++ b/src/compiler/mir/mod.rs
@@ -18,6 +18,7 @@ use super::Span;
 
 mod builder;
 mod ir;
+mod ops;
 mod project;
 mod test;
 mod typetable;

--- a/src/compiler/mir/ops/mod.rs
+++ b/src/compiler/mir/ops/mod.rs
@@ -1,0 +1,4 @@
+//! This module contains different operations which can be applied to a
+//! MIR representation of a function.
+
+mod transformer;

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -32,23 +32,23 @@ pub trait Transformer<L, V> {
     /// Tells the program to exit this [`BasicBlock`] by returning to the calling function
     fn term_return();
 
-    /// Store a given value to the given memory location
+    /// Store the given value to the given memory location
     fn assign(l: L, v: V);
 
     /// Convert a reference to a specific location in memory
     fn lvalue(l: LValue) -> L;
 
     // The following methods correspond to [`RValue`] variants
+
+    /// Convert a constant value
     fn constant(c: Constant) -> V;
-    fn load();
-    fn add();
-    fn subtract();
-    fn mul();
-    fn div();
-    fn neg();
-    fn not();
-    fn and();
-    fn or();
-    fn cast();
-    fn address_of();
+
+    /// Load a value from a memory location
+    fn load() -> V;
+
+    /// Add two values together
+    fn add(a: V, b: V) -> V;
+
+    /// Subtract two values
+    fn sub(a: V, b: V) -> V;
 }


### PR DESCRIPTION
Implement the minimum parts of a trait that defines the interface between the process that traverses the MIR representation of a function and the process that converts the Bramble MIR to another IR (such as LLVM).