### PR TITLE
Refactor the MIR Program Traverser

### DIFF
--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -348,7 +348,7 @@ mod mir2llvm_tests_visual {
 
         let mut llvm = LlvmProgramTransformer::new(&context, &module, &builder, &sm, &table);
 
-        let mut proj_traverser = ProgramTraverser::new(&project);
+        let proj_traverser = ProgramTraverser::new(&project);
 
         // Traverser is given a MirProject
         // call traverser.map(llvm) this will use the llvm xfmr to map MirProject to LlvmProject

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -299,7 +299,7 @@ mod mir2llvm_tests_visual {
             ast::{self, Element, Module, MAIN_MODULE},
             diagnostics::Logger,
             lexer::{tokens::Token, LexerError},
-            mir::{transform, FunctionTraverser, MirProject},
+            mir::{transform, MirProject, ProgramTraverser},
             parser::Parser,
             semantics::semanticnode::SemanticContext,
             CompilerDisplay, CompilerError, Lexer, SourceMap,
@@ -345,17 +345,14 @@ mod mir2llvm_tests_visual {
         let context = Context::create();
         let module = context.create_module("test");
         let builder = context.create_builder();
-        let path: ast::Path = vec![Element::CanonicalRoot, Element::Id(StringId::new())].into();
-        //let mut llvm =
-        //LlvmFunctionTransformer::new(&path, &context, &module, &builder, &sm, &table);
 
         let mut llvm = LlvmProgramTransformer::new(&context, &module, &builder, &sm, &table);
 
-        let mut mvr = FunctionTraverser::new(&project, &mut llvm);
+        let mut proj_traverser = ProgramTraverser::new(&project);
 
         // Traverser is given a MirProject
         // call traverser.map(llvm) this will use the llvm xfmr to map MirProject to LlvmProject
-        mvr.map();
+        proj_traverser.map(&mut llvm);
         // Print LLVM
         println!("=== LLVM IR ===:");
         llvm.module.print_to_stderr();

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -14,6 +14,7 @@ use crate::{
     StringTable,
 };
 
+/// Transforms a complete program from MIR to LLVM IR.
 struct LlvmProgramTransformer<'a, 'ctx> {
     /// LLVVM Context
     context: &'ctx Context,

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -7,7 +7,7 @@ use log::debug;
 
 use crate::{
     compiler::{
-        mir::{ir::*, Transformer, TransformerError},
+        mir::{ir::*, FunctionTransformer, TransformerError},
         Span,
     },
     StringId, StringTable,
@@ -81,7 +81,7 @@ impl<'a, 'ctx> LlvmFunctionTransformer<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> Transformer<PointerValue<'ctx>, BasicValueEnum<'ctx>>
+impl<'a, 'ctx> FunctionTransformer<PointerValue<'ctx>, BasicValueEnum<'ctx>>
     for LlvmFunctionTransformer<'a, 'ctx>
 {
     fn create_bb(&mut self, id: BasicBlockId) -> Result<(), TransformerError> {

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -11,7 +11,7 @@ use crate::{
         mir::{ir::*, DefId, FunctionTransformer, ProgramTransformer, TransformerError},
         SourceMap, Span,
     },
-    StringId, StringTable,
+    StringTable,
 };
 
 struct LlvmProgramTransformer<'a, 'ctx> {

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -348,6 +348,26 @@ mod mir2llvm_tests_visual {
         );
     }
 
+    #[test]
+    fn two_functions() {
+        compile_and_print_llvm(
+            "
+            fn foo() {
+                let x: i64 := if (true) {2} else {3};
+                return;
+            }
+           
+            mod bats {
+                fn bar() {
+                    let x: i64 := 5;
+                    let b: bool := true;
+                    return;
+                }
+            }
+        ",
+        );
+    }
+
     type LResult = std::result::Result<Vec<Token>, CompilerError<LexerError>>;
 
     fn compile_and_print_llvm(text: &str) {

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -56,7 +56,10 @@ impl<'a, 'ctx> LlvmProgramTransformer<'a, 'ctx> {
     }
 }
 
-impl<'a, 'ctx> ProgramTransformer for LlvmProgramTransformer<'a, 'ctx> {
+impl<'a, 'ctx>
+    ProgramTransformer<PointerValue<'ctx>, BasicValueEnum<'ctx>, LlvmFunctionTransformer<'a, 'ctx>>
+    for LlvmProgramTransformer<'a, 'ctx>
+{
     fn add_function(
         &mut self,
         func_id: DefId,
@@ -77,13 +80,10 @@ impl<'a, 'ctx> ProgramTransformer for LlvmProgramTransformer<'a, 'ctx> {
         }
     }
 
-    fn get_function_transformer<L, V, F: FunctionTransformer<L, V>>(
+    fn get_function_transformer(
         &mut self,
-        func_id: DefId,
-    ) -> Result<F, TransformerError> {
-        // Look up function value from DefId
-        // If function not found then return an error
-        // Create a FunctionTransformer for function
+        _: DefId,
+    ) -> std::result::Result<LlvmFunctionTransformer<'a, 'ctx>, TransformerError> {
         todo!()
     }
 }

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -82,9 +82,22 @@ impl<'a, 'ctx>
 
     fn get_function_transformer(
         &mut self,
-        _: DefId,
+        id: DefId,
     ) -> std::result::Result<LlvmFunctionTransformer<'a, 'ctx>, TransformerError> {
-        todo!()
+        // Look up the FunctionValue associated with the given id
+        let fv = self
+            .fn_table
+            .get(&id)
+            .ok_or(TransformerError::FunctionNotFound)?;
+
+        // Create a new fucntion transformer that will populate the assoicated function value
+        Ok(LlvmFunctionTransformer::new(
+            *fv,
+            self.context,
+            self.module,
+            self.builder,
+            self.str_table,
+        ))
     }
 }
 

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -9,7 +9,7 @@ use crate::{
     compiler::{
         ast::Path,
         mir::{ir::*, DefId, FunctionTransformer, ProgramTransformer, TransformerError},
-        SourceMap, Span,
+        CompilerDisplay, SourceMap, Span,
     },
     StringTable,
 };
@@ -55,6 +55,13 @@ impl<'a, 'ctx> LlvmProgramTransformer<'a, 'ctx> {
             str_table: table,
         }
     }
+
+    fn to_label(&self, path: &Path) -> String {
+        path.iter()
+            .map(|element| element.fmt(self.source_map, self.str_table).unwrap())
+            .collect::<Vec<_>>()
+            .join("_")
+    }
 }
 
 impl<'a, 'ctx>
@@ -66,7 +73,7 @@ impl<'a, 'ctx>
         func_id: DefId,
         canonical_path: &Path,
     ) -> Result<(), TransformerError> {
-        let name = canonical_path.to_label(self.source_map, self.str_table);
+        let name = self.to_label(canonical_path);
 
         debug!("Adding function to Module: {}", name);
 

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -13,6 +13,38 @@ use crate::{
     StringId, StringTable,
 };
 
+struct LlvmProgramTransformer<'a, 'ctx> {
+    /// LLVVM Context
+    context: &'ctx Context,
+
+    /// LLVM Module
+    module: &'a Module<'ctx>,
+
+    /// Used to construct actual LLVM instructions and add them to a function
+    builder: &'a Builder<'ctx>,
+
+    /// Table mapping [`StringIds`](StringId) to the string value
+    str_table: &'ctx StringTable,
+}
+
+impl<'a, 'ctx> LlvmProgramTransformer<'a, 'ctx> {
+    pub fn new(
+        ctx: &'ctx Context,
+        module: &'a Module<'ctx>,
+        builder: &'a Builder<'ctx>,
+        table: &'ctx StringTable,
+    ) -> Self {
+        debug!("Creating LLVM Program Transformer");
+
+        Self {
+            context: ctx,
+            module,
+            builder,
+            str_table: table,
+        }
+    }
+}
+
 struct LlvmFunctionTransformer<'a, 'ctx> {
     /// LLVVM Context
     context: &'ctx Context,

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -299,7 +299,7 @@ mod mir2llvm_tests_visual {
             ast::{self, Element, Module, MAIN_MODULE},
             diagnostics::Logger,
             lexer::{tokens::Token, LexerError},
-            mir::{transform, MirProject, Traverser},
+            mir::{transform, FunctionTraverser, MirProject},
             parser::Parser,
             semantics::semanticnode::SemanticContext,
             CompilerDisplay, CompilerError, Lexer, SourceMap,
@@ -351,7 +351,7 @@ mod mir2llvm_tests_visual {
 
         let mut llvm = LlvmProgramTransformer::new(&context, &module, &builder, &sm, &table);
 
-        let mut mvr = Traverser::new(&project, &mut llvm);
+        let mut mvr = FunctionTraverser::new(&project, &mut llvm);
 
         // Traverser is given a MirProject
         // call traverser.map(llvm) this will use the llvm xfmr to map MirProject to LlvmProject

--- a/src/compiler/mir/mod.rs
+++ b/src/compiler/mir/mod.rs
@@ -22,7 +22,7 @@ mod typetable;
 pub mod ir;
 pub mod transform;
 
-pub use ops::{FunctionTransformer, FunctionTraverser, ProgramTransformer, TransformerError};
+pub use ops::{FunctionTransformer, ProgramTransformer, ProgramTraverser, TransformerError};
 pub use project::{DefId, MirProject};
 
 // Unit test modules

--- a/src/compiler/mir/mod.rs
+++ b/src/compiler/mir/mod.rs
@@ -22,8 +22,8 @@ mod typetable;
 pub mod ir;
 pub mod transform;
 
-pub use ops::{FunctionTransformer, TransformerError, Traverser};
-pub use project::MirProject;
+pub use ops::{FunctionTransformer, ProgramTransformer, TransformerError, Traverser};
+pub use project::{DefId, MirProject};
 
 // Unit test modules
 #[cfg(test)]

--- a/src/compiler/mir/mod.rs
+++ b/src/compiler/mir/mod.rs
@@ -22,7 +22,7 @@ mod typetable;
 pub mod ir;
 pub mod transform;
 
-pub use ops::{FunctionTransformer, ProgramTransformer, TransformerError, Traverser};
+pub use ops::{FunctionTransformer, FunctionTraverser, ProgramTransformer, TransformerError};
 pub use project::{DefId, MirProject};
 
 // Unit test modules

--- a/src/compiler/mir/mod.rs
+++ b/src/compiler/mir/mod.rs
@@ -22,7 +22,7 @@ mod typetable;
 pub mod ir;
 pub mod transform;
 
-pub use ops::{Transformer, TransformerError, Traverser};
+pub use ops::{FunctionTransformer, TransformerError, Traverser};
 pub use project::MirProject;
 
 // Unit test modules

--- a/src/compiler/mir/ops/mod.rs
+++ b/src/compiler/mir/ops/mod.rs
@@ -5,4 +5,4 @@ mod transformer;
 mod traverser;
 
 pub use transformer::*;
-pub use traverser::Traverser;
+pub use traverser::FunctionTraverser;

--- a/src/compiler/mir/ops/mod.rs
+++ b/src/compiler/mir/ops/mod.rs
@@ -5,4 +5,4 @@ mod transformer;
 mod traverser;
 
 pub use transformer::*;
-pub use traverser::FunctionTraverser;
+pub use traverser::ProgramTraverser;

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -28,7 +28,7 @@ use crate::compiler::{mir::ir::*, Span};
 /// deconstructing the [`RValue`] enumeration to extract the [`Operands`](Operand)
 /// exists only within the Traverser.
 ///
-/// Furhermore, the Traverser will be responsible for managing the intermediate
+/// Furthermore, the Traverser will be responsible for managing the intermediate
 /// results of converting the [`RValue`] or [`LValue`] prior to the conversion
 /// of the [`Statement`]. To allow for the Traverser to manage the intermediate
 /// values before the conversion of the [`Statement`] a generic type parameter

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -22,6 +22,8 @@ use crate::compiler::{
     Span,
 };
 
+/// Defines the interface used by the [`ProgramTraverser`](super::ProgramTraverser)
+/// to convert a MIR program into another IR form.
 pub trait ProgramTransformer<L, V, F: FunctionTransformer<L, V>> {
     /// Will attempt to Add the given function to the set of functions in the target
     /// IR.

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -16,7 +16,27 @@
 //! the vector.
 //! 5. Need to construct the Phi operator in the merge point Basic Block.
 
-use crate::compiler::{mir::ir::*, Span};
+use crate::compiler::{
+    ast::Path,
+    mir::{ir::*, project::DefId},
+    Span,
+};
+
+pub trait ProgramTransformer {
+    /// Will attempt to Add the given function to the set of functions in the target
+    /// IR.
+    fn add_function(
+        &mut self,
+        func_id: DefId,
+        canonical_path: &Path,
+    ) -> Result<(), TransformerError>;
+
+    /// Creates a new transformer for the given function
+    fn get_function_transformer<L, V, F: FunctionTransformer<L, V>>(
+        &mut self,
+        func_id: DefId,
+    ) -> Result<F, TransformerError>;
+}
 
 /// The MIR Transformer defines an interface between the process which traverses
 /// the MIR (which is a Control Flow Graph) and the process which converts a MIR

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -22,7 +22,7 @@ use crate::compiler::{
     Span,
 };
 
-pub trait ProgramTransformer {
+pub trait ProgramTransformer<L, V, F: FunctionTransformer<L, V>> {
     /// Will attempt to Add the given function to the set of functions in the target
     /// IR.
     fn add_function(
@@ -32,10 +32,7 @@ pub trait ProgramTransformer {
     ) -> Result<(), TransformerError>;
 
     /// Creates a new transformer for the given function
-    fn get_function_transformer<L, V, F: FunctionTransformer<L, V>>(
-        &mut self,
-        func_id: DefId,
-    ) -> Result<F, TransformerError>;
+    fn get_function_transformer(&mut self, func_id: DefId) -> Result<F, TransformerError>;
 }
 
 /// The MIR Transformer defines an interface between the process which traverses

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -40,7 +40,7 @@ use crate::compiler::{mir::ir::*, Span};
 /// is still a reason for this trait to exist. To create a decoupling between the
 /// mir module and the LLVM IR module and avoid having bi-directional imports creating
 /// a more confusing dependency graph.
-pub trait Transformer<L, V> {
+pub trait FunctionTransformer<L, V> {
     fn create_bb(&mut self, bb: BasicBlockId) -> Result<(), TransformerError>;
     fn set_bb(&mut self, bb: BasicBlockId) -> Result<(), TransformerError>;
 

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -112,4 +112,5 @@ pub enum TransformerError {
     BasicBlockNotFound,
     TempNotFound,
     VarNotFound,
+    FunctionAlreadyDeclared,
 }

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -110,4 +110,5 @@ pub enum TransformerError {
     TempNotFound,
     VarNotFound,
     FunctionAlreadyDeclared,
+    FunctionNotFound,
 }

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 
 use log::debug;
 
-use crate::compiler::mir::{ir::*, ops::traverser, MirProject};
+use crate::compiler::mir::{ir::*, MirProject};
 
 use super::{transformer::FunctionTransformer, ProgramTransformer};
 

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -27,7 +27,7 @@ impl<'a> ProgramTraverser<'a> {
         }
 
         // Iterate over every function in MIR
-        /*for (id, f) in self.mir.function_iter() {
+        for (id, f) in self.mir.function_iter() {
             debug!("Transforming: {:?}", f.path());
 
             // For each function, iterate over every BB
@@ -37,7 +37,7 @@ impl<'a> ProgramTraverser<'a> {
             // Create function traverser and pass it the transformer
             let mut traverser = FunctionTraverser::new(self.mir, f, &mut fn_xfm);
             traverser.map();
-        }*/
+        }
     }
 }
 

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -21,8 +21,13 @@ impl<'a> ProgramTraverser<'a> {
     pub fn map<P: ProgramTransformer>(&self, xfmr: &mut P) {
         debug!("Applying given Transformer to MIR");
 
-        // Iterate over every function in MIR
+        // Declare every function in the ProgramTransformer
         for (id, f) in self.mir.function_iter() {
+            xfmr.add_function(id, f.path()).unwrap();
+        }
+
+        // Iterate over every function in MIR
+        /*for (id, f) in self.mir.function_iter() {
             debug!("Transforming: {:?}", f.path());
 
             // For each function, iterate over every BB
@@ -30,9 +35,9 @@ impl<'a> ProgramTraverser<'a> {
             let mut fn_xfm = xfmr.get_function_transformer(id).unwrap();
 
             // Create function traverser and pass it the transformer
-            let mut traverser = FunctionTraverser::new(self.mir, &mut fn_xfm);
+            let mut traverser = FunctionTraverser::new(self.mir, f, &mut fn_xfm);
             traverser.map();
-        }
+        }*/
     }
 }
 

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -7,7 +7,7 @@ use log::debug;
 
 use crate::compiler::mir::{ir::*, MirProject};
 
-use super::transformer::Transformer;
+use super::transformer::FunctionTransformer;
 
 /// This will traverse the MIR representation of a function and use the given
 /// [`Transformer`] implementation to generate a new IR for the function.
@@ -20,7 +20,7 @@ use super::transformer::Transformer;
 ///
 /// `T` - the type that implements the [`Transformer`] trait and will actually handle the
 /// conversion to the target IR.
-pub struct Traverser<'a, L, V, T: Transformer<L, V>> {
+pub struct Traverser<'a, L, V, T: FunctionTransformer<L, V>> {
     xfmr: &'a mut T,
     mir: &'a MirProject,
     function: Option<&'a Procedure>,
@@ -28,7 +28,7 @@ pub struct Traverser<'a, L, V, T: Transformer<L, V>> {
     _v: PhantomData<V>,
 }
 
-impl<'a, L, V, T: Transformer<L, V>> Traverser<'a, L, V, T> {
+impl<'a, L, V, T: FunctionTransformer<L, V>> Traverser<'a, L, V, T> {
     pub fn new(mir: &'a MirProject, xfmr: &'a mut T) -> Self {
         debug!("New Function Traverser");
         Self {

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -20,7 +20,7 @@ use super::transformer::FunctionTransformer;
 ///
 /// `T` - the type that implements the [`Transformer`] trait and will actually handle the
 /// conversion to the target IR.
-pub struct Traverser<'a, L, V, T: FunctionTransformer<L, V>> {
+pub struct FunctionTraverser<'a, L, V, T: FunctionTransformer<L, V>> {
     xfmr: &'a mut T,
     mir: &'a MirProject,
     function: Option<&'a Procedure>,
@@ -28,7 +28,7 @@ pub struct Traverser<'a, L, V, T: FunctionTransformer<L, V>> {
     _v: PhantomData<V>,
 }
 
-impl<'a, L, V, T: FunctionTransformer<L, V>> Traverser<'a, L, V, T> {
+impl<'a, L, V, T: FunctionTransformer<L, V>> FunctionTraverser<'a, L, V, T> {
     pub fn new(mir: &'a MirProject, xfmr: &'a mut T) -> Self {
         debug!("New Function Traverser");
         Self {

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -18,7 +18,10 @@ impl<'a> ProgramTraverser<'a> {
         Self { mir }
     }
 
-    pub fn map<P: ProgramTransformer>(&self, xfmr: &mut P) {
+    pub fn map<L, V, F: FunctionTransformer<L, V>, P: ProgramTransformer<L, V, F>>(
+        &self,
+        xfmr: &mut P,
+    ) {
         debug!("Applying given Transformer to MIR");
 
         // Declare every function in the ProgramTransformer

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -9,7 +9,11 @@ use crate::compiler::mir::{ir::*, MirProject};
 
 use super::{transformer::FunctionTransformer, ProgramTransformer};
 
+/// Traverses all the items in an input [`MirProject`] and orchestrates
+/// a [`ProgramTransformer`] to transform the input MIR into a target
+/// IR form.
 pub struct ProgramTraverser<'a> {
+    /// Reference to the [`MirProject`] being transformed.
     mir: &'a MirProject,
 }
 
@@ -18,6 +22,8 @@ impl<'a> ProgramTraverser<'a> {
         Self { mir }
     }
 
+    /// This function takes an implementation of [`ProgramTransformer`] and uses it to
+    /// conver source MIR value into the target IR form.
     pub fn map<L, V, F: FunctionTransformer<L, V>, P: ProgramTransformer<L, V, F>>(
         &self,
         xfmr: &mut P,

--- a/src/compiler/mir/project.rs
+++ b/src/compiler/mir/project.rs
@@ -82,6 +82,8 @@ impl MirProject {
         self.static_defs.find(path)
     }
 
+    /// Returns an [`Iterator`] over all the functions defined within this
+    /// project.
     pub fn function_iter(&self) -> impl Iterator<Item = (DefId, &Procedure)> {
         self.static_defs.function_iter()
     }

--- a/src/compiler/mir/project.rs
+++ b/src/compiler/mir/project.rs
@@ -82,7 +82,7 @@ impl MirProject {
         self.static_defs.find(path)
     }
 
-    pub fn function_iter(&self) -> impl Iterator<Item = &Procedure> {
+    pub fn function_iter(&self) -> impl Iterator<Item = (DefId, &Procedure)> {
         self.static_defs.function_iter()
     }
 }
@@ -157,9 +157,9 @@ impl StaticDefinitions {
     }
 
     /// Return an iterator over the functions that are defined in a  MIR Program.
-    fn function_iter(&self) -> impl Iterator<Item = &Procedure> {
-        self.defs.iter().map(|i| match i {
-            StaticItem::Function(f) => f,
+    fn function_iter(&self) -> impl Iterator<Item = (DefId, &Procedure)> {
+        self.defs.iter().enumerate().map(|(id, i)| match i {
+            StaticItem::Function(f) => (DefId(id as u32), f),
         })
     }
 }

--- a/src/compiler/mir/project.rs
+++ b/src/compiler/mir/project.rs
@@ -166,7 +166,7 @@ impl StaticDefinitions {
 
 /// Uniquely identifies an item that exists in the static memory of a program
 /// e.g., a function or static variable.
-#[derive(PartialEq, Debug, Copy, Clone, Default)]
+#[derive(Hash, Eq, PartialEq, Debug, Copy, Clone, Default)]
 pub struct DefId(u32);
 
 impl DefId {


### PR DESCRIPTION
This PR splits the traversal and transformation of a MIR Program into two parts: the Program Traverser and the function Traverser and, likewise, a Program Transformer and a Function Transformer.  The Program operators handle adding type definitions and transforming each function.  The Function operators handle transforming the definition of a function to the target.

The function transformation was split out so that management of local variables would be easier and, furthermore, to help enforce that local variable state only exists for that function.