### PR TITLE
Return values from functions

### DIFF
--- a/src/compiler/llvm/llvmir.rs
+++ b/src/compiler/llvm/llvmir.rs
@@ -1633,7 +1633,7 @@ fn convert_esc_seq_to_ascii(s: &str) -> Result<String> {
     Ok(escaped_str)
 }
 
-fn get_ptr_alignment(ptr: PointerValue) -> u32 {
+pub fn get_ptr_alignment(ptr: PointerValue) -> u32 {
     ptr.get_type()
         .get_alignment()
         .get_zero_extended_constant()
@@ -1641,7 +1641,7 @@ fn get_ptr_alignment(ptr: PointerValue) -> u32 {
 }
 
 /// Defines helper functions for interacting with LLVM types
-trait LlvmIsAggregateType {
+pub trait LlvmIsAggregateType {
     /// Returns `true` if the type is an array or a struct
     fn is_aggregate_type(&self) -> bool;
 }

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -333,10 +333,7 @@ pub struct LlvmFunctionBuilder<'p, 'module, 'ctx> {
 }
 
 impl<'p, 'module, 'ctx> LlvmFunctionBuilder<'p, 'module, 'ctx> {
-    pub fn new(
-        function: FunctionData<'ctx>,
-        program: &'p LlvmProgramBuilder<'module, 'ctx>,
-    ) -> Self {
+    fn new(function: FunctionData<'ctx>, program: &'p LlvmProgramBuilder<'module, 'ctx>) -> Self {
         debug!("Creating LLVM Function Transformer for function");
         Self {
             function,

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -585,10 +585,6 @@ impl<'p, 'module, 'ctx> FunctionBuilder<PointerValue<'ctx>, BasicValueEnum<'ctx>
         self.program.builder.build_unconditional_branch(*target);
     }
 
-    fn assign(&mut self, span: Span, l: PointerValue<'ctx>, v: BasicValueEnum<'ctx>) {
-        self.program.builder.build_store(l, v);
-    }
-
     fn store(&mut self, span: Span, l: &LValue, r: BasicValueEnum<'ctx>) {
         match l {
             LValue::Static(_) => todo!(),

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -76,10 +76,14 @@ impl<'module, 'ctx> LlvmProgram<'module, 'ctx> {
     }
 }
 
+/// Groups the data which describes an LLVM function together.
 #[derive(Clone, Copy)]
 struct FunctionData<'ctx> {
-    ret_method: ReturnMethod,
+    /// A reference to the function within the LLVM module.
     function: FunctionValue<'ctx>,
+
+    /// Describes how values are returned from the funciton to the caller.
+    ret_method: ReturnMethod,
 }
 
 /// Specifies the method that will be used to pass the result of this

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -163,6 +163,10 @@ impl<'module, 'ctx> LlvmProgramBuilder<'module, 'ctx> {
     fn get_type(&self, id: TypeId) -> Result<&AnyTypeEnum<'ctx>, TransformerError> {
         self.ty_table.get(&id).ok_or(TransformerError::TypeNotFound)
     }
+
+    fn get_ret_method(ty: TypeId) -> ReturnMethod {
+        ReturnMethod::Return
+    }
 }
 
 impl<'p, 'module, 'ctx>
@@ -178,6 +182,7 @@ impl<'p, 'module, 'ctx>
         func_id: DefId,
         canonical_path: &Path,
         args: &[ArgDecl],
+        ret_ty: TypeId,
     ) -> Result<(), TransformerError> {
         let name = self.to_label(canonical_path);
 
@@ -185,6 +190,7 @@ impl<'p, 'module, 'ctx>
 
         // Determine the channel for the return value
         // Set the return channel property for the function
+        let ret_method = Self::get_ret_method(ret_ty);
 
         // If the functoin returns values via a Output Reference Parameter
         // then make that parameter the first parameter
@@ -201,7 +207,7 @@ impl<'p, 'module, 'ctx>
 
         // Add function to function table
         let function = FunctionData {
-            ret_method: ReturnMethod::Return,
+            ret_method,
             function,
         };
 

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -315,6 +315,9 @@ pub struct LlvmFunctionBuilder<'p, 'module, 'ctx> {
     /// all insructions will be added to this function.
     function: FunctionValue<'ctx>,
 
+    /// Channel used to return the result back to the caller
+    ret_ptr: Option<AnyValueEnum<'ctx>>,
+
     /// Mapping of [`VarIds`](VarId) to their LLVM value, this is used to look up
     /// variables after they have been allocated.
     vars: HashMap<VarId, PointerValue<'ctx>>,
@@ -337,6 +340,7 @@ impl<'p, 'module, 'ctx> LlvmFunctionBuilder<'p, 'module, 'ctx> {
         Self {
             function,
             program,
+            ret_ptr: None,
             vars: HashMap::default(),
             temps: HashMap::default(),
             blocks: HashMap::new(),

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -164,8 +164,19 @@ impl<'module, 'ctx> LlvmProgramBuilder<'module, 'ctx> {
         self.ty_table.get(&id).ok_or(TransformerError::TypeNotFound)
     }
 
-    fn get_ret_method(ty: TypeId) -> ReturnMethod {
-        ReturnMethod::Return
+    fn get_ret_method(&self, ty: TypeId) -> Result<ReturnMethod, TransformerError> {
+        let llvm_ty = self.get_type(ty)?;
+        let method = match llvm_ty {
+            AnyTypeEnum::PointerType(_) | AnyTypeEnum::FloatType(_) | AnyTypeEnum::IntType(_) => {
+                ReturnMethod::Return
+            }
+            AnyTypeEnum::ArrayType(_) => todo!(),
+            AnyTypeEnum::FunctionType(_) => todo!(),
+            AnyTypeEnum::StructType(_) => todo!(),
+            AnyTypeEnum::VectorType(_) => todo!(),
+            AnyTypeEnum::VoidType(_) => todo!(),
+        };
+        Ok(method)
     }
 }
 
@@ -190,7 +201,7 @@ impl<'p, 'module, 'ctx>
 
         // Determine the channel for the return value
         // Set the return channel property for the function
-        let ret_method = Self::get_ret_method(ret_ty);
+        let ret_method = self.get_ret_method(ret_ty)?;
 
         // If the functoin returns values via a Output Reference Parameter
         // then make that parameter the first parameter

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -129,6 +129,17 @@ mod mir2llvm_tests_visual {
         );
     }
 
+    #[test]
+    fn function_return() {
+        compile_and_print_llvm(
+            "
+            fn foo() -> i64 {
+                return 5;
+            }
+        ",
+        );
+    }
+
     type LResult = std::result::Result<Vec<Token>, CompilerError<LexerError>>;
 
     fn compile_and_print_llvm(text: &str) {

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -136,6 +136,10 @@ mod mir2llvm_tests_visual {
             fn foo() -> i64 {
                 return 5;
             }
+
+            fn bar() -> f64 {
+                return 5.0;
+            }
         ",
         );
     }
@@ -144,8 +148,8 @@ mod mir2llvm_tests_visual {
     fn function_return_array() {
         compile_and_print_llvm(
             "
-            fn foo(a: [i32; 4]) -> [i32; 4] {
-                return a;
+            fn foo(a: [i32; 4]) {
+                return;
             }
         ",
         );

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -130,11 +130,22 @@ mod mir2llvm_tests_visual {
     }
 
     #[test]
-    fn function_return() {
+    fn function_return_base_value() {
         compile_and_print_llvm(
             "
             fn foo() -> i64 {
                 return 5;
+            }
+        ",
+        );
+    }
+
+    #[test]
+    fn function_return_array() {
+        compile_and_print_llvm(
+            "
+            fn foo(a: [i32; 4]) -> [i32; 4] {
+                return a;
             }
         ",
         );

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -32,6 +32,7 @@ pub trait ProgramBuilder<'p, L, V, F: FunctionBuilder<L, V>> {
         func_id: DefId,
         canonical_path: &Path,
         args: &[ArgDecl],
+        ret_ty: TypeId,
     ) -> Result<(), TransformerError>;
 
     fn add_type(&mut self, id: TypeId, ty: &MirTypeDef) -> Result<(), TransformerError>;

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -87,6 +87,8 @@ pub trait FunctionBuilder<L, V> {
     /// Store the given value to the given memory location
     fn assign(&mut self, span: Span, l: L, v: V);
 
+    fn store(&mut self, span: Span, l: &LValue, r: V);
+
     /// Convert the given variable declaration to a specific location in memory
     fn var(&self, v: VarId) -> Result<L, TransformerError>;
 

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -85,8 +85,6 @@ pub trait FunctionBuilder<L, V> {
     fn term_goto(&mut self, target_bb: BasicBlockId);
 
     /// Store the given value to the given memory location
-    fn assign(&mut self, span: Span, l: L, v: V);
-
     fn store(&mut self, span: Span, l: &LValue, r: V);
 
     /// Convert the given variable declaration to a specific location in memory

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -166,9 +166,9 @@ impl<'a, L, V, T: FunctionBuilder<L, V>> FunctionTraverser<'a, L, V, T> {
 
         match stm.kind() {
             StatementKind::Assign(lv, rv) => {
-                let lv = self.lvalue(lv);
+                //let lv = self.lvalue(lv);
                 let rv = self.rvalue(rv);
-                self.xfmr.assign(span, lv, rv);
+                self.xfmr.store(span, lv, rv);
             }
         }
     }

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -166,7 +166,6 @@ impl<'a, L, V, T: FunctionBuilder<L, V>> FunctionTraverser<'a, L, V, T> {
 
         match stm.kind() {
             StatementKind::Assign(lv, rv) => {
-                //let lv = self.lvalue(lv);
                 let rv = self.rvalue(rv);
                 self.xfmr.store(span, lv, rv);
             }

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -37,7 +37,8 @@ impl<'a> ProgramTraverser<'a> {
 
         // Declare every function in the ProgramTransformer
         for (id, f) in self.mir.function_iter() {
-            xfmr.add_function(id, f.path(), f.get_args()).unwrap();
+            xfmr.add_function(id, f.path(), f.get_args(), f.ret_ty())
+                .unwrap();
         }
 
         // Iterate over every function in MIR


### PR DESCRIPTION
This PR adds support for converting the storing to the `ReturnPointer` to the MIR 2 LLVM converter. This adds a field to the Function Builder which keeps track of the location of where the return value will go in order to be passed back to the call site.

If a function returns an aggregate type, then it will be classified as using the `OutParam` return method. If the function returns a base type, then it is classified as using the `Return` method.  The `OutParam` method uses an "out" parameter which contains an address to a location provided by the caller, the return value is then written to the memory pointed to by that address.  The `Return` method, uses LLVM's `return` operator to return a base value from the function.

This PR lays the foundation for returning arrays and structures from a function, but leaves the full implementation to the PRs that will add arrays and structures to the MIR 2 LLVM transformer.