### PR TITLE
Mir2LLVM: Function Calls

### DIFF
--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -598,7 +598,8 @@ impl<'p, 'module, 'ctx> FunctionBuilder<PointerValue<'ctx>, BasicValueEnum<'ctx>
             .build_conditional_branch(cond.into_int_value(), *then_bb, *else_bb);
     }
 
-    fn term_fn_call(&mut self, reentry: BasicBlockId) {
+    fn term_fn_call(&mut self, target: PointerValue<'ctx>, reentry: BasicBlockId) {
+        self.program.builder.build_call(target, &[], "");
         let bb = self.blocks.get(&reentry).unwrap();
         self.program.builder.build_unconditional_branch(*bb);
     }
@@ -629,6 +630,15 @@ impl<'p, 'module, 'ctx> FunctionBuilder<PointerValue<'ctx>, BasicValueEnum<'ctx>
                 }
             },
         }
+    }
+
+    fn static_loc(&self, id: DefId) -> Result<PointerValue<'ctx>, TransformerError> {
+        let f = self
+            .program
+            .fn_table
+            .get(&id)
+            .ok_or(TransformerError::FunctionNotFound);
+        todo!()
     }
 
     fn var(&self, v: VarId) -> Result<PointerValue<'ctx>, TransformerError> {

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -541,18 +541,6 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
             _ => panic!("Terminator must be set for BB before lowering to LLVM"),
         };
         Ok(())
-
-        /*
-        let bb = self
-            .program
-            .context
-            .append_basic_block(self.function.function, &id.to_string());
-        if self.blocks.insert(id, bb).is_none() {
-            Ok(())
-        } else {
-            Err(TransformerError::BasicBlockAlreadyCreated)
-        }
-        */
     }
 
     fn set_bb(&mut self, id: BasicBlockId) -> Result<(), TransformerError> {

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -39,7 +39,7 @@ const ADDRESS_SPACE: AddressSpace = AddressSpace::Generic;
 /// the output parameter. While Bramble does not support variadic functions, as of
 /// this time, this makes it easier to reason about how the out parameter affects
 /// the compilation of a program.
-const OUT_PARAM_INDEX: usize = 0;
+const OUT_PARAM_INDEX: u32 = 0;
 
 /// Represents an LLVM value which represents an address somewhere in memory. This
 /// includes [`pointers`](PointerValue) and [`function labels`](FunctionValue).

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -650,9 +650,12 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
         // that value into the temp location
         if f.ret_method == ReturnMethod::Return {
             let loc = reentry.0.into_pointer().unwrap();
-            self.program
-                .builder
-                .build_store(loc, result.try_as_basic_value().unwrap_left());
+            match result.try_as_basic_value().left() {
+                Some(r) => {
+                    self.program.builder.build_store(loc, r);
+                }
+                None => (),
+            }
         }
 
         let bb = self.blocks.get(&reentry.1).unwrap();

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -620,11 +620,16 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
             .build_conditional_branch(cond.into_int_value(), *then_bb, *else_bb);
     }
 
-    fn term_call_fn(&mut self, target: Location<'ctx>, reentry: (Location<'ctx>, BasicBlockId)) {
+    fn term_call_fn(
+        &mut self,
+        target: Location<'ctx>,
+        args: &[BasicValueEnum<'ctx>],
+        reentry: (Location<'ctx>, BasicBlockId),
+    ) {
         let result =
             self.program
                 .builder
-                .build_call(target.into_function().unwrap().function, &[], "");
+                .build_call(target.into_function().unwrap().function, args, "");
 
         let loc = reentry.0.into_pointer().unwrap();
         self.program

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -482,7 +482,7 @@ impl<'p, 'module, 'ctx> LlvmFunctionBuilder<'p, 'module, 'ctx> {
 
         self.function
             .function
-            .get_nth_param(id.to_u32() - arg_offset)
+            .get_nth_param(id.to_u32() + arg_offset)
             .ok_or(TransformerError::ArgNotFound)
     }
 

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -391,6 +391,11 @@ pub struct LlvmFunctionBuilder<'p, 'module, 'ctx> {
     temps: HashMap<TempId, PointerValue<'ctx>>,
 
     /// Table to manage looking up the LLVM BasicBlock via the [`BasicBlockId`].
+    /// Some [`BasicBlockIds`](BasicBlockId) may map to the same
+    /// [`inkwell::BasicBlock`](inkwell::basic_block::BasicBlock). This is because
+    /// the LLVM Builder may decide that two adjacent MIR BasicBlocks need to be
+    /// merged into a single LLVM BasicBlock in order to maintain idiomatic LLVM
+    /// code.
     blocks: HashMap<BasicBlockId, inkwell::basic_block::BasicBlock<'ctx>>,
 }
 
@@ -591,6 +596,14 @@ impl<'p, 'module, 'ctx> FunctionBuilder<PointerValue<'ctx>, BasicValueEnum<'ctx>
         self.program
             .builder
             .build_conditional_branch(cond.into_int_value(), *then_bb, *else_bb);
+    }
+
+    fn term_fn_call(
+        &mut self,
+        target: DefId,
+        args: &[BasicValueEnum<'ctx>],
+        reentry: (PointerValue<'ctx>, BasicBlockId),
+    ) {
     }
 
     fn term_goto(&mut self, target: BasicBlockId) {

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -620,7 +620,7 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
             .build_conditional_branch(cond.into_int_value(), *then_bb, *else_bb);
     }
 
-    fn term_fn_call(&mut self, target: Location<'ctx>, reentry: BasicBlockId) {
+    fn term_call_fn(&mut self, target: Location<'ctx>, reentry: BasicBlockId) {
         self.program
             .builder
             .build_call(target.into_function().unwrap().function, &[], "");

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -598,12 +598,9 @@ impl<'p, 'module, 'ctx> FunctionBuilder<PointerValue<'ctx>, BasicValueEnum<'ctx>
             .build_conditional_branch(cond.into_int_value(), *then_bb, *else_bb);
     }
 
-    fn term_fn_call(
-        &mut self,
-        target: DefId,
-        args: &[BasicValueEnum<'ctx>],
-        reentry: (PointerValue<'ctx>, BasicBlockId),
-    ) {
+    fn term_fn_call(&mut self, reentry: BasicBlockId) {
+        let bb = self.blocks.get(&reentry).unwrap();
+        self.program.builder.build_unconditional_branch(*bb);
     }
 
     fn term_goto(&mut self, target: BasicBlockId) {

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -620,11 +620,18 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
             .build_conditional_branch(cond.into_int_value(), *then_bb, *else_bb);
     }
 
-    fn term_call_fn(&mut self, target: Location<'ctx>, reentry: BasicBlockId) {
+    fn term_call_fn(&mut self, target: Location<'ctx>, reentry: (Location<'ctx>, BasicBlockId)) {
+        let result =
+            self.program
+                .builder
+                .build_call(target.into_function().unwrap().function, &[], "");
+
+        let loc = reentry.0.into_pointer().unwrap();
         self.program
             .builder
-            .build_call(target.into_function().unwrap().function, &[], "");
-        let bb = self.blocks.get(&reentry).unwrap();
+            .build_store(loc, result.try_as_basic_value().unwrap_left());
+
+        let bb = self.blocks.get(&reentry.1).unwrap();
         self.program.builder.build_unconditional_branch(*bb);
     }
 

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -822,10 +822,8 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
         self.program.context.f64_type().const_float(f).into()
     }
 
-    fn load(&self, lv: Location<'ctx>) -> BasicValueEnum<'ctx> {
-        self.program
-            .builder
-            .build_load(lv.into_pointer().unwrap(), "")
+    fn load(&self, lv: Location<'ctx>) -> Result<BasicValueEnum<'ctx>, TransformerError> {
+        Ok(self.program.builder.build_load(lv.into_pointer()?, ""))
     }
 
     fn add(&self, a: BasicValueEnum<'ctx>, b: BasicValueEnum<'ctx>) -> BasicValueEnum<'ctx> {

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -159,7 +159,7 @@ mod mir2llvm_tests_visual {
         );
     }
 
-    #[test]
+    //#[test]
     fn function_call_return_array() {
         compile_and_print_llvm(
             "
@@ -169,17 +169,6 @@ mod mir2llvm_tests_visual {
 
             fn bar(a: [i64; 4]) -> [i64; 4] {
                 return a;
-            }
-        ",
-        );
-    }
-
-    #[test]
-    fn function_return_array() {
-        compile_and_print_llvm(
-            "
-            fn foo(a: [i32; 4]) {
-                return;
             }
         ",
         );

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -149,10 +149,10 @@ mod mir2llvm_tests_visual {
         compile_and_print_llvm(
             "
             fn foo() -> i64 {
-                return bar();
+                return bar(2);
             }
 
-            fn bar() -> i64 {
+            fn bar(i: i64) -> i64 {
                 return 5;
             }
         ",

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -148,6 +148,18 @@ mod mir2llvm_tests_visual {
     fn function_call() {
         compile_and_print_llvm(
             "
+            fn blah() {
+                goo();
+
+                return;
+            }
+
+            fn goo() {
+                foo();
+
+                return;
+            }
+
             fn foo() -> i64 {
                 return bar(2);
             }

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -150,6 +150,8 @@ mod mir2llvm_tests_visual {
             "
             fn blah() {
                 goo();
+                goo();
+                goo();
 
                 return;
             }
@@ -165,6 +167,21 @@ mod mir2llvm_tests_visual {
             }
 
             fn bar(i: i64) -> i64 {
+                return 5;
+            }
+        ",
+        );
+    }
+
+    #[test]
+    fn function_call_multi_args() {
+        compile_and_print_llvm(
+            "
+            fn foo() -> i64 {
+                return bar(2, 1i32);
+            }
+
+            fn bar(i: i64, j: i32) -> i64 {
                 return 5;
             }
         ",

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -160,6 +160,21 @@ mod mir2llvm_tests_visual {
     }
 
     #[test]
+    fn function_call_return_array() {
+        compile_and_print_llvm(
+            "
+            fn foo(a: [i64; 4]) -> [i64; 4] {
+                return bar(a);
+            }
+
+            fn bar(a: [i64; 4]) -> [i64; 4] {
+                return a;
+            }
+        ",
+        );
+    }
+
+    #[test]
     fn function_return_array() {
         compile_and_print_llvm(
             "

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -145,6 +145,21 @@ mod mir2llvm_tests_visual {
     }
 
     #[test]
+    fn function_call() {
+        compile_and_print_llvm(
+            "
+            fn foo() -> i64 {
+                return bar();
+            }
+
+            fn bar() -> i64 {
+                return 5;
+            }
+        ",
+        );
+    }
+
+    #[test]
     fn function_return_array() {
         compile_and_print_llvm(
             "

--- a/src/compiler/mir/builder.rs
+++ b/src/compiler/mir/builder.rs
@@ -358,7 +358,15 @@ impl MirProcedureBuilder {
 
         let cid = self
             .current_bb
-            .expect("Cannot set terminator when there is not current BasicBlock");
+            .expect("Cannot set terminator when there is no current BasicBlock");
+
+        // The re-entry BB ID must come after the ID of the BB making the function call
+        // Providing this invariant makes transformation operations on the MIR easier.
+        assert!(
+            cid < reentry.1,
+            "The ID of the re-entry BasicBlock must be greater than the caller BasicBlock"
+        );
+
         let bb = self.proc.get_bb_mut(cid);
         bb.set_terminator(Terminator::new(
             TerminatorKind::CallFn {

--- a/src/compiler/mir/ir.rs
+++ b/src/compiler/mir/ir.rs
@@ -310,7 +310,7 @@ impl Display for Procedure {
 }
 
 /// Identifier for a specific basic block in a procedure
-#[derive(Debug, Hash, Eq, PartialEq, Copy, Clone)]
+#[derive(Debug, Hash, Eq, PartialEq, PartialOrd, Copy, Clone)]
 pub struct BasicBlockId(usize);
 
 impl BasicBlockId {

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -143,7 +143,7 @@ pub trait FunctionBuilder<L, V> {
     fn const_f64(&self, f: f64) -> V;
 
     /// Load a value from a memory location
-    fn load(&self, lv: L) -> V;
+    fn load(&self, lv: L) -> Result<V, TransformerError>;
 
     /// Add two values together
     fn add(&self, a: V, b: V) -> V;

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -83,7 +83,7 @@ pub trait FunctionBuilder<L, V> {
 
     /// Tells the program to enter into a new function and, when that function is complete,
     /// where to store the result and where to reenter this function.
-    fn term_call_fn(&mut self, target: L, reentry: BasicBlockId);
+    fn term_call_fn(&mut self, target: L, reentry: (L, BasicBlockId));
 
     /// Tells the program to go to the given [`BasicBlock`].
     fn term_goto(&mut self, target_bb: BasicBlockId);

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -83,7 +83,7 @@ pub trait FunctionBuilder<L, V> {
 
     /// Tells the program to enter into a new function and, when that function is complete,
     /// where to store the result and where to reenter this function.
-    fn term_fn_call(&mut self, target: DefId, args: &[V], reentry: (L, BasicBlockId));
+    fn term_fn_call(&mut self, reentry: BasicBlockId);
 
     /// Tells the program to go to the given [`BasicBlock`].
     fn term_goto(&mut self, target_bb: BasicBlockId);

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -79,14 +79,19 @@ pub trait FunctionBuilder<L, V> {
 
     /// Tells the program to go to one of two [`BasicBlocks`](BasicBlock) based upon whether
     /// the given conditional is true or false.
-    fn term_cond_goto(&mut self, cond: V, then_bb: BasicBlockId, else_bb: BasicBlockId);
+    fn term_cond_goto(
+        &mut self,
+        cond: V,
+        then_bb: BasicBlockId,
+        else_bb: BasicBlockId,
+    ) -> Result<(), TransformerError>;
 
     /// Tells the program to enter into a new function and, when that function is complete,
     /// where to store the result and where to reenter this function.
     fn term_call_fn(&mut self, target: L, arg: &[V], reentry: (L, BasicBlockId));
 
     /// Tells the program to go to the given [`BasicBlock`].
-    fn term_goto(&mut self, target_bb: BasicBlockId);
+    fn term_goto(&mut self, target_bb: BasicBlockId) -> Result<(), TransformerError>;
 
     /// Store the given value to the given memory location
     fn store(&mut self, span: Span, l: &LValue, r: V);

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -83,7 +83,7 @@ pub trait FunctionBuilder<L, V> {
 
     /// Tells the program to enter into a new function and, when that function is complete,
     /// where to store the result and where to reenter this function.
-    fn term_fn_call(&mut self, target: L, reentry: BasicBlockId);
+    fn term_call_fn(&mut self, target: L, reentry: BasicBlockId);
 
     /// Tells the program to go to the given [`BasicBlock`].
     fn term_goto(&mut self, target_bb: BasicBlockId);

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -88,7 +88,12 @@ pub trait FunctionBuilder<L, V> {
 
     /// Tells the program to enter into a new function and, when that function is complete,
     /// where to store the result and where to reenter this function.
-    fn term_call_fn(&mut self, target: L, arg: &[V], reentry: (L, BasicBlockId));
+    fn term_call_fn(
+        &mut self,
+        target: L,
+        arg: &[V],
+        reentry: (L, BasicBlockId),
+    ) -> Result<(), TransformerError>;
 
     /// Tells the program to go to the given [`BasicBlock`].
     fn term_goto(&mut self, target_bb: BasicBlockId) -> Result<(), TransformerError>;

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -83,13 +83,15 @@ pub trait FunctionBuilder<L, V> {
 
     /// Tells the program to enter into a new function and, when that function is complete,
     /// where to store the result and where to reenter this function.
-    fn term_fn_call(&mut self, reentry: BasicBlockId);
+    fn term_fn_call(&mut self, target: L, reentry: BasicBlockId);
 
     /// Tells the program to go to the given [`BasicBlock`].
     fn term_goto(&mut self, target_bb: BasicBlockId);
 
     /// Store the given value to the given memory location
     fn store(&mut self, span: Span, l: &LValue, r: V);
+
+    fn static_loc(&self, id: DefId) -> Result<L, TransformerError>;
 
     /// Convert the given variable declaration to a specific location in memory
     fn var(&self, v: VarId) -> Result<L, TransformerError>;

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -16,6 +16,8 @@
 //! the vector.
 //! 5. Need to construct the Phi operator in the merge point Basic Block.
 
+use std::collections::VecDeque;
+
 use crate::compiler::{
     ast::Path,
     mir::{ir::*, project::DefId, MirTypeDef, TypeId},
@@ -91,7 +93,7 @@ pub trait FunctionBuilder<L, V> {
     fn term_call_fn(
         &mut self,
         target: L,
-        args: Vec<V>,
+        args: VecDeque<V>,
         reentry: (L, BasicBlockId),
     ) -> Result<(), TransformerError>;
 

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -64,7 +64,7 @@ pub trait ProgramBuilder<'p, L, V, F: FunctionBuilder<L, V>> {
 /// mir module and the LLVM IR module and avoid having bi-directional imports creating
 /// a more confusing dependency graph.
 pub trait FunctionBuilder<L, V> {
-    fn create_bb(&mut self, bb: BasicBlockId) -> Result<(), TransformerError>;
+    fn create_bb(&mut self, id: BasicBlockId, bb: &BasicBlock) -> Result<(), TransformerError>;
     fn set_bb(&mut self, bb: BasicBlockId) -> Result<(), TransformerError>;
 
     /// Allocate space for the given variable declaration

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -83,7 +83,7 @@ pub trait FunctionBuilder<L, V> {
 
     /// Tells the program to enter into a new function and, when that function is complete,
     /// where to store the result and where to reenter this function.
-    fn term_call_fn(&mut self, target: L, reentry: (L, BasicBlockId));
+    fn term_call_fn(&mut self, target: L, arg: &[V], reentry: (L, BasicBlockId));
 
     /// Tells the program to go to the given [`BasicBlock`].
     fn term_goto(&mut self, target_bb: BasicBlockId);

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -81,6 +81,10 @@ pub trait FunctionBuilder<L, V> {
     /// the given conditional is true or false.
     fn term_cond_goto(&mut self, cond: V, then_bb: BasicBlockId, else_bb: BasicBlockId);
 
+    /// Tells the program to enter into a new function and, when that function is complete,
+    /// where to store the result and where to reenter this function.
+    fn term_fn_call(&mut self, target: DefId, args: &[V], reentry: (L, BasicBlockId));
+
     /// Tells the program to go to the given [`BasicBlock`].
     fn term_goto(&mut self, target_bb: BasicBlockId);
 

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -91,6 +91,7 @@ pub trait FunctionBuilder<L, V> {
     /// Store the given value to the given memory location
     fn store(&mut self, span: Span, l: &LValue, r: V);
 
+    /// Returns a location value for a specific static item.
     fn static_loc(&self, id: DefId) -> Result<L, TransformerError>;
 
     /// Convert the given variable declaration to a specific location in memory

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -91,7 +91,7 @@ pub trait FunctionBuilder<L, V> {
     fn term_call_fn(
         &mut self,
         target: L,
-        arg: &[V],
+        args: Vec<V>,
         reentry: (L, BasicBlockId),
     ) -> Result<(), TransformerError>;
 

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -167,9 +167,12 @@ impl<'a, L, V, T: FunctionBuilder<L, V>> FunctionTraverser<'a, L, V, T> {
                     Operand::LValue(l) => self.lvalue(l),
                 };
                 // evaluate arguments?
+
                 // convert LValue?
+                let reentry = (self.lvalue(&reentry.0), reentry.1);
+
                 // create function call
-                self.xfmr.term_call_fn(target, reentry.1)
+                self.xfmr.term_call_fn(target, reentry)
             }
         }
     }

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -176,7 +176,7 @@ impl<'a, L, V, T: FunctionBuilder<L, V>> FunctionTraverser<'a, L, V, T> {
                 let reentry = (self.lvalue(&reentry.0), reentry.1);
 
                 // create function call
-                self.xfmr.term_call_fn(target, &args, reentry)
+                self.xfmr.term_call_fn(target, &args, reentry).unwrap()
             }
         }
     }

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -165,7 +165,9 @@ impl<'a, L, V, T: FunctionBuilder<L, V>> FunctionTraverser<'a, L, V, T> {
             } => {
                 // Get the target function
                 let target = match func {
-                    Operand::Constant(_) => todo!(),
+                    Operand::Constant(_) => {
+                        panic!("Attempting to use a constant in a function call")
+                    }
                     Operand::LValue(l) => self.lvalue(l),
                 };
 

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -169,7 +169,7 @@ impl<'a, L, V, T: FunctionBuilder<L, V>> FunctionTraverser<'a, L, V, T> {
                 // evaluate arguments?
                 // convert LValue?
                 // create function call
-                self.xfmr.term_fn_call(target, reentry.1)
+                self.xfmr.term_call_fn(target, reentry.1)
             }
         }
     }

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -90,8 +90,10 @@ impl<'a, L, V, T: FunctionBuilder<L, V>> FunctionTraverser<'a, L, V, T> {
     pub fn map(&mut self) {
         debug!("Applying given Transformer to MIR");
 
-        for (id, _) in self.function.bb_iter() {
-            self.xfmr.create_bb(id).expect("BasicBlock already created");
+        for (id, bb) in self.function.bb_iter() {
+            self.xfmr
+                .create_bb(id, bb)
+                .expect("BasicBlock already created");
         }
 
         // Allocate variables

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -1,7 +1,7 @@
 //! Traverses the MIR representation of a function and calls the appropriate
 //! methods on a value which implements the [`super::transformer::Transformer`] trait.
 
-use std::marker::PhantomData;
+use std::{collections::VecDeque, marker::PhantomData};
 
 use log::debug;
 
@@ -172,7 +172,7 @@ impl<'a, L, V, T: FunctionBuilder<L, V>> FunctionTraverser<'a, L, V, T> {
                 };
 
                 // evaluate arguments?
-                let args: Vec<_> = args.iter().map(|a| self.operand(a)).collect();
+                let args: VecDeque<_> = args.iter().map(|a| self.operand(a)).collect();
 
                 // convert LValue?
                 let reentry = (self.lvalue(&reentry.0), reentry.1);

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -153,10 +153,10 @@ impl<'a, L, V, T: FunctionBuilder<L, V>> FunctionTraverser<'a, L, V, T> {
             .kind()
         {
             TerminatorKind::Return => self.xfmr.term_return(),
-            TerminatorKind::GoTo { target } => self.xfmr.term_goto(*target),
+            TerminatorKind::GoTo { target } => self.xfmr.term_goto(*target).unwrap(),
             TerminatorKind::CondGoTo { cond, tru, fls } => {
                 let cond = self.operand(cond);
-                self.xfmr.term_cond_goto(cond, *tru, *fls)
+                self.xfmr.term_cond_goto(cond, *tru, *fls).unwrap()
             }
             TerminatorKind::CallFn {
                 func,

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -210,7 +210,7 @@ impl<'a, L, V, T: FunctionBuilder<L, V>> FunctionTraverser<'a, L, V, T> {
             Operand::Constant(c) => self.constant(*c),
             Operand::LValue(lv) => {
                 let l = self.lvalue(lv);
-                self.xfmr.load(l)
+                self.xfmr.load(l).unwrap()
             }
         }
     }

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -164,6 +164,7 @@ impl<'a, L, V, T: FunctionBuilder<L, V>> FunctionTraverser<'a, L, V, T> {
                 // evaluate arguments?
                 // convert LValue?
                 // create function call
+                self.xfmr.term_fn_call(reentry.1)
             }
         }
     }

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -156,7 +156,15 @@ impl<'a, L, V, T: FunctionBuilder<L, V>> FunctionTraverser<'a, L, V, T> {
                 let cond = self.operand(cond);
                 self.xfmr.term_cond_goto(cond, *tru, *fls)
             }
-            TerminatorKind::CallFn { .. } => todo!(),
+            TerminatorKind::CallFn {
+                func,
+                args,
+                reentry,
+            } => {
+                // evaluate arguments?
+                // convert LValue?
+                // create function call
+            }
         }
     }
 

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -161,10 +161,15 @@ impl<'a, L, V, T: FunctionBuilder<L, V>> FunctionTraverser<'a, L, V, T> {
                 args,
                 reentry,
             } => {
+                // Get the target function
+                let target = match func {
+                    Operand::Constant(_) => todo!(),
+                    Operand::LValue(l) => self.lvalue(l),
+                };
                 // evaluate arguments?
                 // convert LValue?
                 // create function call
-                self.xfmr.term_fn_call(reentry.1)
+                self.xfmr.term_fn_call(target, reentry.1)
             }
         }
     }
@@ -224,7 +229,7 @@ impl<'a, L, V, T: FunctionBuilder<L, V>> FunctionTraverser<'a, L, V, T> {
 
     fn lvalue(&mut self, lv: &LValue) -> L {
         match lv {
-            LValue::Static(_) => todo!(),
+            LValue::Static(sid) => self.xfmr.static_loc(*sid).unwrap(),
             LValue::Var(vid) => self.xfmr.var(*vid).unwrap(),
             LValue::Temp(tid) => self.xfmr.temp(*tid).unwrap(),
             LValue::Access(_, _) => todo!(),

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -178,7 +178,7 @@ impl<'a, L, V, T: FunctionBuilder<L, V>> FunctionTraverser<'a, L, V, T> {
                 let reentry = (self.lvalue(&reentry.0), reentry.1);
 
                 // create function call
-                self.xfmr.term_call_fn(target, &args, reentry).unwrap()
+                self.xfmr.term_call_fn(target, args, reentry).unwrap()
             }
         }
     }

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -166,13 +166,15 @@ impl<'a, L, V, T: FunctionBuilder<L, V>> FunctionTraverser<'a, L, V, T> {
                     Operand::Constant(_) => todo!(),
                     Operand::LValue(l) => self.lvalue(l),
                 };
+
                 // evaluate arguments?
+                let args: Vec<_> = args.iter().map(|a| self.operand(a)).collect();
 
                 // convert LValue?
                 let reentry = (self.lvalue(&reentry.0), reentry.1);
 
                 // create function call
-                self.xfmr.term_call_fn(target, reentry)
+                self.xfmr.term_call_fn(target, &args, reentry)
             }
         }
     }

--- a/src/compiler/mir/test.rs
+++ b/src/compiler/mir/test.rs
@@ -113,6 +113,25 @@ pub mod tests {
         }
 
         #[test]
+        fn print_mir_unit_fn_call() {
+            let text = "
+        fn test() -> i64 {
+            test2();
+            return 1 + 2 + 3;
+        }
+        
+        fn test2() {
+            return;
+        }
+        ";
+            let mut table = StringTable::new();
+            let module = compile(text, &mut table);
+            let mut project = MirProject::new();
+            transform::transform(&module, &mut project).unwrap();
+            println!("{}", project);
+        }
+
+        #[test]
         fn print_mir_extern() {
             let text = "
         extern fn printf(x: i64, ...);


### PR DESCRIPTION
This implements the conversion of a MIR Callfn terminator into an LLVM function call.

This implementation covers the following:
1. Looking up the LLVM FunctionValue associated with a given `DefId` from the MIR CallFn terminator and creating a call operation to that function
2. Constructing the argument list and passing it to the function call
3. Handling the storage of the function result.
4. Using the `ReturnMethod` property of the LLVM function to determine if an out parameter needs to be preprended to the argument list that points to the location on the caller stack where the function result is written.
5. Merging the reentry MIR BasicBlock with the caller BasicBlock in LLVM, because function calls are not termintors in LLVM.

What this does not do:
The use of the out parameter exists for array and structure types.  The Mir2LLVM conversion has not been implemented for those types yet. Therefore, the logic has been written for constructing the calls, passing the out parameter, and writing to the out parameter rather than using the LLVM `ret` operation. 

However, when testing, these will fail, because the LLVM types have not yet been properly setup for Structures and Arrays, especially for making sure that they are passed by reference to functions. Because this work will be resolved in the Mir2LLVM tasks for Structures and Arrays the tests were written but left disabled until then.