### PR TITLE
T120 mir2llvm Array parameters

### DIFF
--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -612,6 +612,7 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
     fn alloc_arg(&mut self, arg_id: ArgId, decl: &ArgDecl) -> Result<(), TransformerError> {
         let name = self.arg_label(decl);
         let arg_value = self.get_arg(arg_id)?;
+        arg_value.set_name(&name);
 
         // Check if variable name already exists
         let var_id = decl.var_id().unwrap();

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -62,6 +62,7 @@ pub enum LlvmBuilderError {
     CoerceRetPtrIntoFn,
     CoerceValueIntoPointer,
     CoerceValueIntoFn,
+    ReadInvalidLocation,
 }
 
 impl TransformerInternalError for LlvmBuilderError {}
@@ -771,10 +772,10 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
                     Ok(self.program.builder.build_load(lv.into_pointer()?, ""))
                 }
             }
-            Location::Function(_) => todo!(),
             Location::Argument(arg) => Ok(arg),
-            Location::ReturnPointer => todo!(),
-            Location::Void => todo!(),
+            Location::Function(_) | Location::ReturnPointer | Location::Void => Err(
+                TransformerError::Internal(&LlvmBuilderError::ReadInvalidLocation),
+            ),
         }
     }
 
@@ -798,7 +799,7 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
                 }
             },
             Location::Void => (),
-            Location::Argument(_) => todo!(),
+            Location::Argument(_) => panic!("Cannot store to an argument"),
         }
     }
 

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -635,7 +635,10 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
         // Check if variable name already exists
         match self.vars.entry(id) {
             // If it does -> return an error
-            Entry::Occupied(_) => Ok(()),
+            Entry::Occupied(occ) => match occ.get() {
+                Location::Argument(_) => Ok(()),
+                _ => Err(TransformerError::VariableAlreadyAllocated),
+            },
 
             // If not, then allocate a pointer in the Builder
             Entry::Vacant(ve) => {

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -672,21 +672,6 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
         }
     }
 
-    fn store_arg(&mut self, arg_id: ArgId, var_id: VarId) -> Result<(), TransformerError> {
-        // Get the argument value
-        let arg_value = self.get_arg(arg_id)?;
-
-        // Get the location in the stack where the argument will be stored
-        self.vars
-            .get(&var_id)
-            .ok_or(TransformerError::VarNotFound)?
-            .into_pointer()
-            .and_then(|loc| {
-                self.program.builder.build_store(loc, arg_value);
-                Ok(())
-            })
-    }
-
     fn term_return(&mut self) {
         match self.ret_ptr {
             ReturnPointer::Unit => self.program.builder.build_return(None),

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -60,7 +60,8 @@ pub enum LlvmBuilderError {
     CoercePtrLocationIntoFn,
     CoerceRetPtrIntoPtr,
     CoerceRetPtrIntoFn,
-    CoerceArgIntoPointer,
+    CoerceValueIntoPointer,
+    CoerceValueIntoFn,
 }
 
 impl TransformerInternalError for LlvmBuilderError {}
@@ -80,7 +81,10 @@ impl<'ctx> Location<'ctx> {
             Location::Function(_) => Err(&LlvmBuilderError::CoerceFnLocationIntoPointer),
             Location::ReturnPointer => Err(&LlvmBuilderError::CoerceRetPtrIntoPtr),
             Location::Void => Err(&LlvmBuilderError::CoerceVoidLocationIntoPointer),
-            Location::Argument(_) => Err(&LlvmBuilderError::CoerceArgIntoPointer),
+            Location::Argument(arg) => match arg {
+                BasicValueEnum::PointerValue(ptr) => Ok(*ptr),
+                _ => Err(&LlvmBuilderError::CoerceValueIntoPointer),
+            },
         }
         .map_err(|e| TransformerError::Internal(e))
     }
@@ -93,7 +97,7 @@ impl<'ctx> Location<'ctx> {
             Location::Function(f) => Ok(*f),
             Location::ReturnPointer => Err(&LlvmBuilderError::CoerceRetPtrIntoFn),
             Location::Void => Err(&LlvmBuilderError::CoerceVoidLocationIntoFunction),
-            Location::Argument(_) => todo!(),
+            Location::Argument(_) => Err(&LlvmBuilderError::CoerceValueIntoFn),
         }
         .map_err(|e| TransformerError::Internal(e))
     }

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -887,7 +887,12 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
     }
 
     fn load(&self, lv: Location<'ctx>) -> Result<BasicValueEnum<'ctx>, TransformerError> {
-        Ok(self.program.builder.build_load(lv.into_pointer()?, ""))
+        let ptr = lv.into_pointer()?;
+        if ptr.get_type().get_element_type().is_aggregate_type() {
+            Ok(ptr.into())
+        } else {
+            Ok(self.program.builder.build_load(lv.into_pointer()?, ""))
+        }
     }
 
     fn add(&self, a: BasicValueEnum<'ctx>, b: BasicValueEnum<'ctx>) -> BasicValueEnum<'ctx> {

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -230,6 +230,17 @@ mod mir2llvm_tests_visual {
     }
 
     #[test]
+    fn function_array_argument() {
+        compile_and_print_llvm(
+            "
+            fn baz(arr: [i64; 2]) -> i64 {
+                return arr[0];
+            }
+        ",
+        );
+    }
+
+    #[test]
     fn function_return_array() {
         compile_and_print_llvm(
             "

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -68,6 +68,19 @@ mod mir2llvm_tests_visual {
     }
 
     #[test]
+    fn simple_array_expression() {
+        let text = "
+            fn test() {
+                let mut a: [i8; 2] :=  [1i8, 2i8];
+
+                return;
+            }
+        ";
+
+        compile_and_print_llvm(text);
+    }
+
+    #[test]
     fn base_array_expressions() {
         let text = "
             fn test() -> f64 {
@@ -221,10 +234,16 @@ mod mir2llvm_tests_visual {
         compile_and_print_llvm(
             "
             fn foo(a: [i64; 4]) {
+                let x: i64 := a[0];
                 return;
             }
 
-            /*fn bar(a: [i64; 4]) -> [i64; 4] {
+            fn bar() -> [i64; 2] {
+                let a: [i64; 2] := [1, 2];
+                return a;
+            }
+
+            /*fn bar(a: [i64; 4], b: [i64; 8], c: [i64; 16]) -> [i64; 4] {
                 return a;
             }*/
         ",
@@ -237,6 +256,9 @@ mod mir2llvm_tests_visual {
         let (sm, table, module) = compile(text);
         let mut project = MirProject::new();
         transform::transform(&module, &mut project).unwrap();
+
+        println!("=== MIR ===:");
+        println!("{}\n\n", project);
 
         let context = Context::create();
         let module = context.create_module("test");

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -252,6 +252,17 @@ mod mir2llvm_tests_visual {
     }
 
     #[test]
+    fn function_return_array_parameter() {
+        compile_and_print_llvm(
+            "
+            fn baz(a: [i64; 2]) -> [i64; 2] {
+                return a;
+            }
+        ",
+        );
+    }
+
+    #[test]
     fn function_call_return_array() {
         compile_and_print_llvm(
             "

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -238,6 +238,10 @@ mod mir2llvm_tests_visual {
                 return;
             }
 
+            fn baz() -> [i64; 2] {
+                return [1, 2];
+            }
+
             fn bar() -> [i64; 2] {
                 let a: [i64; 2] := [1, 2];
                 return a;

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -230,26 +230,28 @@ mod mir2llvm_tests_visual {
     }
 
     #[test]
-    fn function_call_return_array() {
+    fn function_return_array() {
         compile_and_print_llvm(
             "
-            /*fn foo(a: [i64; 4]) {
-                let x: i64 := a[0];
-                return;
-            }*/
-
             fn baz() -> [i64; 2] {
                 return [1, 2];
             }
+        ",
+        );
+    }
 
-            /*fn bar() -> [i64; 2] {
-                let a: [i64; 2] := [1, 2];
-                return a;
+    #[test]
+    fn function_call_return_array() {
+        compile_and_print_llvm(
+            "
+            fn foo() {
+                let a: [i64; 2] := bar();
+                return;
             }
 
-            fn bar(a: [i64; 4], b: [i64; 8], c: [i64; 16]) -> [i64; 4] {
-                return a;
-            }*/
+            fn bar() -> [i64; 2] {
+                return [1, 2];
+            }
         ",
         );
     }

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -223,7 +223,7 @@ mod mir2llvm_tests_visual {
             }
 
             fn bar(i: i64, j: i32) -> i64 {
-                return 5;
+                return i;
             }
         ",
         );

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -233,21 +233,21 @@ mod mir2llvm_tests_visual {
     fn function_call_return_array() {
         compile_and_print_llvm(
             "
-            fn foo(a: [i64; 4]) {
+            /*fn foo(a: [i64; 4]) {
                 let x: i64 := a[0];
                 return;
-            }
+            }*/
 
             fn baz() -> [i64; 2] {
                 return [1, 2];
             }
 
-            fn bar() -> [i64; 2] {
+            /*fn bar() -> [i64; 2] {
                 let a: [i64; 2] := [1, 2];
                 return a;
             }
 
-            /*fn bar(a: [i64; 4], b: [i64; 8], c: [i64; 16]) -> [i64; 4] {
+            fn bar(a: [i64; 4], b: [i64; 8], c: [i64; 16]) -> [i64; 4] {
                 return a;
             }*/
         ",

--- a/src/compiler/mir/ir.rs
+++ b/src/compiler/mir/ir.rs
@@ -429,6 +429,7 @@ impl ArgDecl {
         self.var_id
     }
 
+    /// Return the name of this argument
     pub fn name(&self) -> StringId {
         self.name
     }

--- a/src/compiler/mir/ir.rs
+++ b/src/compiler/mir/ir.rs
@@ -428,6 +428,10 @@ impl ArgDecl {
     pub fn var_id(&self) -> Option<VarId> {
         self.var_id
     }
+
+    pub fn name(&self) -> StringId {
+        self.name
+    }
 }
 
 /// Unique identifier for an argument within the MIR of a function

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -101,6 +101,9 @@ pub trait FunctionBuilder<L, V> {
     /// Tells the program to go to the given [`BasicBlock`].
     fn term_goto(&mut self, target_bb: BasicBlockId) -> Result<(), TransformerError>;
 
+    /// Load a value from a memory location
+    fn load(&self, lv: L) -> Result<V, TransformerError>;
+
     /// Store the given value to the given memory location
     fn store(&mut self, span: Span, l: L, r: V);
 
@@ -151,9 +154,6 @@ pub trait FunctionBuilder<L, V> {
 
     /// Create a const [`f64`].
     fn const_f64(&self, f: f64) -> V;
-
-    /// Load a value from a memory location
-    fn load(&self, lv: L) -> Result<V, TransformerError>;
 
     /// Add two values together
     fn add(&self, a: V, b: V) -> V;

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -74,9 +74,6 @@ pub trait FunctionBuilder<L, V> {
     fn alloc_var(&mut self, id: VarId, vd: &VarDecl) -> Result<(), TransformerError>;
     fn alloc_temp(&mut self, id: TempId, vd: &TempDecl) -> Result<(), TransformerError>;
 
-    /// Store the value of the given function parameter in the given stack location
-    fn store_arg(&mut self, arg_id: ArgId, var_id: VarId) -> Result<(), TransformerError>;
-
     /// Tells the program to exit this [`BasicBlock`] by returning to the calling function
     fn term_return(&mut self);
 

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -70,6 +70,7 @@ pub trait FunctionBuilder<L, V> {
     fn set_bb(&mut self, bb: BasicBlockId) -> Result<(), TransformerError>;
 
     /// Allocate space for the given variable declaration
+    fn alloc_arg(&mut self, id: ArgId, decl: &ArgDecl) -> Result<(), TransformerError>;
     fn alloc_var(&mut self, id: VarId, vd: &VarDecl) -> Result<(), TransformerError>;
     fn alloc_temp(&mut self, id: TempId, vd: &TempDecl) -> Result<(), TransformerError>;
 

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -113,20 +113,20 @@ impl<'a, L, V, T: FunctionBuilder<L, V>> FunctionTraverser<'a, L, V, T> {
             .set_bb(ENTRY_BB)
             .expect("There must be at least one BasicBlock for a function");
 
+        // Loop through all arguments and add them to the function builder
+
+        // Move function parameters into local variables
+        for (id, arg) in self.function.arg_iter() {
+            // get span from arg decl
+            // get value of the llvm function parameter associated with arg id
+            self.xfmr.alloc_arg(id, arg).unwrap();
+        }
+
         // Loop through all user defined variables and allocate them
         // in the Entry BasicBlock
         for id in self.get_varid_iter() {
             let decl = *self.get_var(id);
             self.xfmr.alloc_var(id, &decl).unwrap();
-        }
-
-        // Move function parameters into local variables
-        for (id, arg) in self.function.arg_iter() {
-            // Use arg id to look up the associated var id
-            let var_id = arg.var_id().unwrap();
-            // get span from arg decl
-            // get value of the llvm function parameter associated with arg id
-            self.xfmr.store_arg(id, var_id).unwrap();
         }
 
         // Loop through all temp vars and allocate them


### PR DESCRIPTION
Implement support for array parameters on functions.

This also improves the conversion of function parameters into LLVM. Before, a location on the stack was allocated for every function parameter and the parameter value was stored in that location.  But this is unnecessary cost because parameters are immutable in Bramble. It also created issues with properly determining what LLVM type to put into the stack for array parameters (it would need to store the pointer to the array passed by the caller, which means that the LLVM type of the variable would be a pointer to a pointer).

Now Arguments have a special Argument variant on the Location enumeration which stores the BasicValue that LLVM uses to represent the argument.

If the parameter is an array, then the basic value is a pointer to that array and when trying to use the array in an operation, we convert the BasicValueEnum stored in the Location::Argument variant to it's actual PointerValue type and then use that in the LLVM operations.