### PR TITLE
T131 mir2llvm string literals alternate

### DIFF
--- a/src/compiler/llvm/llvmir.rs
+++ b/src/compiler/llvm/llvmir.rs
@@ -1602,7 +1602,7 @@ impl ast::Type {
 }
 
 /// Convert any escape senquences to their ascii codes
-fn convert_esc_seq_to_ascii(s: &str) -> Result<String> {
+pub fn convert_esc_seq_to_ascii(s: &str) -> Result<String> {
     let mut is_escape = false;
     let mut escaped_str = String::new();
     for c in s.chars() {

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -22,7 +22,7 @@ use crate::{
         },
         CompilerDisplay, SourceMap, Span,
     },
-    StringTable,
+    StringId, StringTable,
 };
 
 use super::llvmir::{get_ptr_alignment, LlvmIsAggregateType, LlvmToBasicTypeEnum};
@@ -470,7 +470,13 @@ impl MirBaseType {
             MirBaseType::Unit => Some(context.void_type().into()),
             // TODO: Should Null this actually make it to MIR?
             MirBaseType::Null => None,
-            MirBaseType::StringLiteral => None,
+            MirBaseType::StringLiteral => Some(
+                context
+                    .i8_type()
+                    .array_type(0)
+                    .ptr_type(AddressSpace::Generic)
+                    .into(),
+            ),
         }
     }
 }
@@ -492,6 +498,8 @@ pub struct LlvmFunctionBuilder<'p, 'module, 'ctx> {
     /// Mapping of [`TempIds`](TempId) to their LLVM value, this is used to look up
     /// variables after they have been allocated.
     temps: HashMap<TempId, Location<'ctx>>,
+
+    string_literals: HashMap<StringId, Location<'ctx>>,
 
     /// Table to manage looking up the LLVM BasicBlock via the [`BasicBlockId`].
     /// Some [`BasicBlockIds`](BasicBlockId) may map to the same
@@ -538,7 +546,8 @@ impl<'p, 'module, 'ctx> LlvmFunctionBuilder<'p, 'module, 'ctx> {
             ret_ptr,
             vars: HashMap::default(),
             temps: HashMap::default(),
-            blocks: HashMap::new(),
+            string_literals: HashMap::default(),
+            blocks: HashMap::default(),
         }
     }
 
@@ -582,6 +591,20 @@ impl<'p, 'module, 'ctx> LlvmFunctionBuilder<'p, 'module, 'ctx> {
 
     fn temp_label(&self, id: TempId) -> String {
         format!("_{}", id.index())
+    }
+
+    /// Convert the ID of a string to the name of the global variable that
+    /// references that string
+    fn create_stringpool_label(&self, id: StringId) -> String {
+        format!(
+            "str_{}_{}",
+            self.program
+                .module
+                .get_name()
+                .to_str()
+                .expect("Expected a valid UTF string for the Module name"),
+            id
+        )
     }
 
     fn build_memcpy(&mut self, dest: PointerValue<'ctx>, src: PointerValue<'ctx>, span: Span) {
@@ -985,6 +1008,33 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
 
     fn const_f64(&self, f: f64) -> BasicValueEnum<'ctx> {
         self.program.context.f64_type().const_float(f).into()
+    }
+
+    fn string_literal(&mut self, id: StringId) -> BasicValueEnum<'ctx> {
+        if self.string_literals.contains_key(&id) {
+            match self.string_literals.get(&id) {
+                Some(l) => l.into_pointer().unwrap().into(),
+                None => todo!(),
+            }
+        } else {
+            let s = self.program.str_table.get(id).unwrap();
+            let escaped_s = super::llvmir::convert_esc_seq_to_ascii(&s).unwrap();
+            let len_w_null = escaped_s.len() + 1;
+            let g = self.program.module.add_global(
+                self.program.context.i8_type().array_type(len_w_null as u32),
+                None,
+                &self.create_stringpool_label(id),
+            );
+            g.set_initializer(
+                &self
+                    .program
+                    .context
+                    .const_string(escaped_s.as_bytes(), true),
+            );
+            let ptr = g.as_pointer_value();
+            self.string_literals.insert(id, Location::Pointer(ptr));
+            ptr.into()
+        }
     }
 
     fn i_add(

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -13,6 +13,8 @@ mod mir2llvm_tests_visual {
     //! used correctly: if LLVM is incorrectly used then it will fault and the unit tests
     //! will fail.
 
+    use std::ffi::{CStr, CString};
+
     use inkwell::{context::Context, execution_engine::JitFunction};
 
     use crate::{
@@ -818,17 +820,21 @@ mod mir2llvm_tests_visual {
 
     #[test]
     fn string_literal() {
-        let _: () = compile_and_run(
+        let r: u64 = compile_and_run(
             "
             extern fn printf(s: string, ...);
+            extern fn strcat(a: string, b: string) -> string;
+            extern fn strlen(s: string) -> u64;
 
-            fn foo() {
-                printf(\"hello\\n\");
-                return;
+            fn foo() -> u64 {
+                let s: string := strcat(\"hello\", \", world\");
+                printf(\"%s\\n\", s);
+                return strlen(s);
             }
         ",
             "main_foo",
         );
+        assert_eq!("hello, world".len(), r as usize);
     }
 
     type LResult = std::result::Result<Vec<Token>, CompilerError<LexerError>>;

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -816,6 +816,21 @@ mod mir2llvm_tests_visual {
         assert_eq!(2.2, r);
     }
 
+    #[test]
+    fn string_literal() {
+        let _: () = compile_and_run(
+            "
+            extern fn printf(s: string, ...);
+
+            fn foo() {
+                printf(\"hello\\n\");
+                return;
+            }
+        ",
+            "main_foo",
+        );
+    }
+
     type LResult = std::result::Result<Vec<Token>, CompilerError<LexerError>>;
 
     fn compile_and_print_llvm(text: &str) {

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -829,6 +829,10 @@ mod mir2llvm_tests_visual {
             fn foo() -> u64 {
                 let s: string := strcat(\"hello\", \", world\");
                 printf(\"%s\\n\", s);
+                return bar(s);
+            }
+
+            fn bar(s: string) -> u64 {
                 return strlen(s);
             }
         ",

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -827,13 +827,14 @@ mod mir2llvm_tests_visual {
             extern fn strlen(s: string) -> u64;
 
             fn foo() -> u64 {
-                let s: string := strcat(\"hello\", \", world\");
+                let s: string := bar(\"hello\", \", world\");
                 printf(\"%s\\n\", s);
-                return bar(s);
+                return strlen(s);
             }
 
-            fn bar(s: string) -> u64 {
-                return strlen(s);
+            fn bar(a: string, b: string) -> string {
+                let s: string := strcat(a, b);
+                return s;
             }
         ",
             "main_foo",

--- a/src/compiler/mir/builder.rs
+++ b/src/compiler/mir/builder.rs
@@ -5,7 +5,7 @@ use crate::{
     StringId,
 };
 
-use super::{ir::*, typetable::*};
+use super::{ir::*, typetable::*, DefId};
 
 /// Provides a Builder interface for constructing the MIR CFG representation of a
 /// routine. This will keep track of the current [`BasicBlock`] and make sure that
@@ -125,7 +125,7 @@ impl MirProcedureBuilder {
     }
 
     /// Create a reference to a string literal
-    pub fn const_stringliteral(&self, s: StringId) -> Operand {
+    pub fn const_stringliteral(&self, s: DefId) -> Operand {
         Operand::Constant(Constant::StringLiteral(s))
     }
 

--- a/src/compiler/mir/ir.rs
+++ b/src/compiler/mir/ir.rs
@@ -786,7 +786,7 @@ pub enum Constant {
     U64(u64),
     F64(f64),
     Bool(bool),
-    StringLiteral(StringId),
+    StringLiteral(DefId),
     Null,
     SizeOf(TypeId),
 }

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -18,10 +18,13 @@
 
 use std::{collections::VecDeque, fmt::Debug};
 
-use crate::compiler::{
-    ast::Path,
-    mir::{ir::*, project::DefId, typetable::FieldId, MirTypeDef, TypeId},
-    Span,
+use crate::{
+    compiler::{
+        ast::Path,
+        mir::{ir::*, project::DefId, typetable::FieldId, MirTypeDef, TypeId},
+        Span,
+    },
+    StringId,
 };
 
 /// Defines the interface used by the [`ProgramTraverser`](super::ProgramTraverser)
@@ -155,6 +158,9 @@ pub trait FunctionBuilder<L, V> {
 
     /// Create a const [`f64`].
     fn const_f64(&self, f: f64) -> V;
+
+    /// Returns a pointer to the given string literal
+    fn string_literal(&mut self, s: StringId) -> V;
 
     /// Add two values together
     fn i_add(&self, a: V, b: V) -> Result<V, TransformerError>;

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -277,7 +277,7 @@ impl<'a, L, V, T: FunctionBuilder<L, V>> FunctionTraverser<'a, L, V, T> {
             Constant::U64(u) => self.xfmr.const_u64(u),
             Constant::F64(f) => self.xfmr.const_f64(f),
             Constant::Bool(b) => self.xfmr.const_bool(b),
-            Constant::StringLiteral(_) => todo!(),
+            Constant::StringLiteral(s) => self.xfmr.string_literal(s),
             Constant::Null => todo!(),
             Constant::SizeOf(_) => todo!(),
         }

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -277,7 +277,11 @@ impl<'a, L, V, T: FunctionBuilder<L, V>> FunctionTraverser<'a, L, V, T> {
             Constant::U64(u) => self.xfmr.const_u64(u),
             Constant::F64(f) => self.xfmr.const_f64(f),
             Constant::Bool(b) => self.xfmr.const_bool(b),
-            Constant::StringLiteral(s) => self.xfmr.string_literal(s),
+            Constant::StringLiteral(s) => self.xfmr.string_literal(
+                self.mir
+                    .get_def_string(s)
+                    .expect("DefId must refer to a static string literal"),
+            ),
             Constant::Null => todo!(),
             Constant::SizeOf(_) => todo!(),
         }

--- a/src/compiler/mir/project.rs
+++ b/src/compiler/mir/project.rs
@@ -87,8 +87,18 @@ impl MirProject {
         }
     }
 
+    /// Adds a new [String Literal](StringId) to the static definition table of this project
     pub fn add_string_literal(&mut self, id: StringId) -> Result<DefId, StaticDefinitionError> {
         self.static_defs.add_string_literal(id)
+    }
+
+    /// Will return a [`StringId`] if the given [`DefId`] maps to a string literal, otherwise,
+    /// this will return [`None`].
+    pub fn get_def_string(&self, id: DefId) -> Option<StringId> {
+        match self.static_defs.get(id) {
+            StaticItem::Function(_) => None,
+            StaticItem::StringLiteral(s) => Some(*s),
+        }
     }
 
     /// Search the set of static definitions for an item with a [path](Path) that is equal
@@ -226,7 +236,7 @@ impl StaticDefinitions {
 pub struct DefId(u32);
 
 impl DefId {
-    fn new(id: u32) -> DefId {
+    pub fn new(id: u32) -> DefId {
         DefId(id)
     }
 }

--- a/src/compiler/mir/project.rs
+++ b/src/compiler/mir/project.rs
@@ -168,7 +168,7 @@ impl StaticDefinitions {
                     *def = func;
                     Ok(idx)
                 }
-                StaticItem::StringLiteral(_) => todo!(),
+                StaticItem::StringLiteral(_) => Err(StaticDefinitionError::NotFunction),
             }
         } else {
             // If _not_ found then add to defs and return the DefId
@@ -256,4 +256,6 @@ pub enum StaticItem {
 }
 
 #[derive(Debug)]
-pub enum StaticDefinitionError {}
+pub enum StaticDefinitionError {
+    NotFunction,
+}

--- a/src/compiler/mir/test.rs
+++ b/src/compiler/mir/test.rs
@@ -523,7 +523,7 @@ pub mod tests {
             (
                 Type::StringLiteral,
                 Expression::StringLiteral((), hello),
-                Constant::StringLiteral(hello),
+                Constant::StringLiteral(DefId::new(1)),
             ),
             (
                 Type::RawPointer(PointerMut::Const, Box::new(Type::I16)),

--- a/src/compiler/mir/test.rs
+++ b/src/compiler/mir/test.rs
@@ -294,7 +294,7 @@ pub mod tests {
 
         let path: Path = to_path(&["main", "test"], &table);
         let def_id = project.find_def(&path).unwrap();
-        let StaticItem::Function(mir) = project.get_def(def_id);
+        let mir = project.get_def_fn(def_id).unwrap();
 
         let bb = mir.get_bb(BasicBlockId::new(0));
         let first = bb.get_stm(0);
@@ -342,7 +342,7 @@ pub mod tests {
 
         let path: Path = to_path(&["main", "test"], &table);
         let def_id = project.find_def(&path).unwrap();
-        let StaticItem::Function(mir) = project.get_def(def_id);
+        let mir = project.get_def_fn(def_id).unwrap();
 
         let bb = mir.get_bb(BasicBlockId::new(0));
         let last = bb.get_stm(bb.len() - 1);
@@ -376,7 +376,7 @@ pub mod tests {
 
         let path: Path = to_path(&["main", "test"], &table);
         let def_id = project.find_def(&path).unwrap();
-        let StaticItem::Function(mir) = project.get_def(def_id);
+        let mir = project.get_def_fn(def_id).unwrap();
 
         let bb = mir.get_bb(BasicBlockId::new(0));
         let last = bb.get_stm(bb.len() - 1);
@@ -437,7 +437,7 @@ pub mod tests {
 
                 let path: Path = to_path(&["main", "test"], &table);
                 let def_id = project.find_def(&path).unwrap();
-                let StaticItem::Function(mir) = project.get_def(def_id);
+                let mir = project.get_def_fn(def_id).unwrap();
 
                 let bb = mir.get_bb(BasicBlockId::new(0));
                 let stm = bb.get_stm(3);
@@ -493,7 +493,7 @@ pub mod tests {
 
                 let path: Path = to_path(&["main", "test"], &table);
                 let def_id = project.find_def(&path).unwrap();
-                let StaticItem::Function(mir) = project.get_def(def_id);
+                let mir = project.get_def_fn(def_id).unwrap();
 
                 let bb = mir.get_bb(BasicBlockId::new(0));
                 let stm = bb.get_stm(1);
@@ -552,7 +552,7 @@ pub mod tests {
 
             let path: Path = to_path(&["main", "test"], &table);
             let def_id = project.find_def(&path).unwrap();
-            let StaticItem::Function(mir) = project.get_def(def_id);
+            let mir = project.get_def_fn(def_id).unwrap();
 
             let bb = mir.get_bb(BasicBlockId::new(0));
             let stm = bb.get_stm(0);
@@ -647,7 +647,7 @@ pub mod tests {
 
                 let path: Path = to_path(&["main", "test"], &table);
                 let def_id = project.find_def(&path).unwrap();
-                let StaticItem::Function(mir) = project.get_def(def_id);
+                let mir = project.get_def_fn(def_id).unwrap();
 
                 let bb = mir.get_bb(BasicBlockId::new(0));
                 let stm = bb.get_stm(0);
@@ -718,7 +718,7 @@ pub mod tests {
 
             let path: Path = to_path(&["main", "test"], &table);
             let def_id = project.find_def(&path).unwrap();
-            let StaticItem::Function(mir) = project.get_def(def_id);
+            let mir = project.get_def_fn(def_id).unwrap();
 
             let bb = mir.get_bb(BasicBlockId::new(0));
             let stm = bb.get_stm(0);
@@ -764,7 +764,7 @@ pub mod tests {
 
                 let path: Path = to_path(&["main", "test"], &table);
                 let def_id = project.find_def(&path).unwrap();
-                let StaticItem::Function(mir) = project.get_def(def_id);
+                let mir = project.get_def_fn(def_id).unwrap();
 
                 let bb = mir.get_bb(BasicBlockId::new(0));
                 let stm = bb.get_stm(0);
@@ -814,7 +814,7 @@ pub mod tests {
 
             let path: Path = to_path(&["main", "test"], &table);
             let def_id = project.find_def(&path).unwrap();
-            let StaticItem::Function(mir) = project.get_def(def_id);
+            let mir = project.get_def_fn(def_id).unwrap();
 
             let bb = mir.get_bb(BasicBlockId::new(0));
 
@@ -868,7 +868,7 @@ pub mod tests {
 
             let path: Path = to_path(&["main", "test"], &table);
             let def_id = project.find_def(&path).unwrap();
-            let StaticItem::Function(mir) = project.get_def(def_id);
+            let mir = project.get_def_fn(def_id).unwrap();
 
             let bb = mir.get_bb(BasicBlockId::new(0));
             let stm = bb.get_stm(0);
@@ -896,7 +896,7 @@ pub mod tests {
 
         let path: Path = to_path(&["main", "test"], &table);
         let def_id = project.find_def(&path).unwrap();
-        let StaticItem::Function(mir) = project.get_def(def_id);
+        let mir = project.get_def_fn(def_id).unwrap();
 
         // Check that the right number of BBs are created
         assert_eq!(mir.len(), 1);
@@ -940,7 +940,7 @@ pub mod tests {
 
         let path: Path = to_path(&["main", "test"], &table);
         let def_id = project.find_def(&path).unwrap();
-        let StaticItem::Function(mir) = project.get_def(def_id);
+        let mir = project.get_def_fn(def_id).unwrap();
 
         // Check that the right number of BBs are created
         assert_eq!(mir.len(), 1);
@@ -996,7 +996,7 @@ pub mod tests {
 
         let path: Path = to_path(&["main", "test"], &table);
         let def_id = project.find_def(&path).unwrap();
-        let StaticItem::Function(mir) = project.get_def(def_id);
+        let mir = project.get_def_fn(def_id).unwrap();
 
         // Check that the right number of BBs are created
         assert_eq!(mir.len(), 4);
@@ -1049,7 +1049,7 @@ pub mod tests {
 
         let path: Path = to_path(&["main", "test"], &table);
         let def_id = project.find_def(&path).unwrap();
-        let StaticItem::Function(mir) = project.get_def(def_id);
+        let mir = project.get_def_fn(def_id).unwrap();
 
         assert_eq!(mir.len(), 1);
         let bb = mir.get_bb(BasicBlockId::new(0));
@@ -1101,7 +1101,7 @@ pub mod tests {
 
         let path: Path = to_path(&["main", "test"], &table);
         let def_id = project.find_def(&path).unwrap();
-        let StaticItem::Function(mir) = project.get_def(def_id);
+        let mir = project.get_def_fn(def_id).unwrap();
 
         assert_eq!(mir.len(), 1);
         let bb = mir.get_bb(BasicBlockId::new(0));
@@ -1161,13 +1161,13 @@ pub mod tests {
 
         let path: Path = to_path(&["main", "test"], &table);
         let def_id = project.find_def(&path).unwrap();
-        let StaticItem::Function(mir) = project.get_def(def_id);
+        let mir = project.get_def_fn(def_id).unwrap();
         assert_eq!(mir.len(), 1);
         assert_eq!(mir.path(), &path);
 
         let path2: Path = to_path(&["main", "test2"], &table);
         let def2_id = project.find_def(&path2).unwrap();
-        let StaticItem::Function(mir2) = project.get_def(def2_id);
+        let mir2 = project.get_def_fn(def2_id).unwrap();
         assert_eq!(mir2.len(), 1);
         assert_eq!(mir2.path(), &path2);
 
@@ -1193,7 +1193,7 @@ pub mod tests {
 
         let path: Path = to_path(&["main", "test"], &table);
         let def_id = project.find_def(&path).unwrap();
-        let StaticItem::Function(mir) = project.get_def(def_id);
+        let mir = project.get_def_fn(def_id).unwrap();
         assert_eq!(mir.len(), 2); // There should be 2: the first BB calls the func and the second is the reentry BB
         assert_eq!(mir.path(), &path);
 
@@ -1245,7 +1245,7 @@ pub mod tests {
 
         let path: Path = to_path(&["main", "test"], &table);
         let def_id = project.find_def(&path).unwrap();
-        let StaticItem::Function(mir) = project.get_def(def_id);
+        let mir = project.get_def_fn(def_id).unwrap();
         assert_eq!(mir.len(), 2); // There should be 2: the first BB calls the func and the second is the reentry BB
         assert_eq!(mir.path(), &path);
 
@@ -1293,7 +1293,7 @@ pub mod tests {
 
         let path: Path = to_path(&["main", "test"], &table);
         let expected_target = project.find_def(&path).unwrap();
-        let StaticItem::Function(mir) = project.get_def(expected_target);
+        let mir = project.get_def_fn(expected_target).unwrap();
         assert_eq!(mir.len(), 2); // There should be 2: the first BB calls the func and the second is the reentry BB
         assert_eq!(mir.path(), &path);
 
@@ -1338,7 +1338,7 @@ pub mod tests {
 
         let path: Path = to_path(&["main", "test"], &table);
         let def_id = project.find_def(&path).unwrap();
-        let StaticItem::Function(mir) = project.get_def(def_id);
+        let mir = project.get_def_fn(def_id).unwrap();
         assert_eq!(mir.len(), 2); // There should be 2: the first BB calls the func and the second is the reentry BB
         assert_eq!(mir.path(), &path);
 
@@ -1387,7 +1387,7 @@ pub mod tests {
 
         let path: Path = to_path(&["main", "test"], &table);
         let def_id = project.find_def(&path).unwrap();
-        let StaticItem::Function(mir) = project.get_def(def_id);
+        let mir = project.get_def_fn(def_id).unwrap();
         assert_eq!(mir.len(), 2); // There should be 2: the first BB calls the func and the second is the reentry BB
         assert_eq!(mir.path(), &path);
 
@@ -1396,7 +1396,7 @@ pub mod tests {
         let expected_target = project.find_def(&path).unwrap();
 
         // check that the extern is variadic
-        let StaticItem::Function(target_def) = project.get_def(expected_target);
+        let target_def = project.get_def_fn(expected_target).unwrap();
         assert!(target_def.has_varargs());
 
         // Check the BB terminator
@@ -1439,7 +1439,7 @@ pub mod tests {
 
         let path: Path = to_path(&["main", "test"], &table);
         let def_id = project.find_def(&path).unwrap();
-        let StaticItem::Function(mir) = project.get_def(def_id);
+        let mir = project.get_def_fn(def_id).unwrap();
 
         // Check that the right number of BBs are created
         assert_eq!(mir.len(), 1);
@@ -1477,7 +1477,7 @@ pub mod tests {
 
         let path: Path = to_path(&["main", "test"], &table);
         let def_id = project.find_def(&path).unwrap();
-        let StaticItem::Function(mir) = project.get_def(def_id);
+        let mir = project.get_def_fn(def_id).unwrap();
 
         assert_eq!(mir.len(), 1);
         let bb = mir.get_bb(BasicBlockId::new(0));

--- a/src/compiler/mir/transform/function.rs
+++ b/src/compiler/mir/transform/function.rs
@@ -127,7 +127,12 @@ impl<'a> FuncTransformer<'a> {
             Expression::F64(_, f) => self.mir.const_f64(*f),
             Expression::Null(_) => self.mir.const_null(),
             Expression::Boolean(_, b) => self.mir.const_bool(*b),
-            Expression::StringLiteral(_, sid) => self.mir.const_stringliteral(*sid),
+            Expression::StringLiteral(_, sid) => {
+                // If it exists Get static definition of the string literal
+                let def_id = self.project.add_string_literal(*sid).unwrap();
+                // Otherwise, add the string literal to hte static definition table
+                self.mir.const_stringliteral(def_id)
+            }
 
             // Operations
             Expression::BinaryOp(ctx, op, left, right) => {

--- a/src/compiler/mir/transform/function.rs
+++ b/src/compiler/mir/transform/function.rs
@@ -262,7 +262,10 @@ impl<'a> FuncTransformer<'a> {
         let reentry_bb = self.mir.new_bb();
 
         // Look up the declaration of the target function
-        let StaticItem::Function(func) = self.project.get_def(fn_id);
+        let func = self
+            .project
+            .get_def_fn(fn_id)
+            .expect("No function bound to given DefId");
 
         // Create a temp location for the result value of the function call
         let result = self.mir.temp(func.ret_ty(), ctx.span());

--- a/src/compiler/stringtable.rs
+++ b/src/compiler/stringtable.rs
@@ -90,7 +90,7 @@ impl StringTable {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
+#[derive(Clone, Copy, PartialEq, Debug, Default, Hash, Eq)]
 pub struct StringId(u32);
 
 impl StringId {


### PR DESCRIPTION
This PR enables an alternative design for supporting string literals in the MIR system.

String literals are mapped to locations within the static definition table (just like functions) and are assigned a unique `DefId`. This `DefId` is then used to refer to the string literal in the MIR language. This is consistent with the MIR representing the physical sections/locations within the layout of a program's memory. String literals would lay in the `.data` or static memory section of a program and, therefore, the MIR should reflect that. This static memory location is also where the definitions for functions would be stored.

The Mir2Llvm builder then uses the `DefId` to look up the `StringId` which is then used to look up the actual string value itself. The StringId and the string value are used to create global variables in the LLVM language and those global variables are used as the values within the compiled LLVM code.

## Testing
This PR also enables a new unit testing capability in the Mir2LLVM converter test module. Functions will now be compiled into the LLVM JIT and executed with test input. This will not only confirm that value LLVM is being generated but that it is also correct.

Only a few tests have been setup to use this new feature.