### PR TITLE
Temp revert temp var optimization

### DIFF
--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -65,7 +65,6 @@ pub enum Location<'ctx> {
     Pointer(PointerValue<'ctx>),
     Function(FunctionData<'ctx>),
     Argument(BasicValueEnum<'ctx>),
-    Temp(TempId, Option<BasicValueEnum<'ctx>>),
     ReturnPointer,
     Void,
 }
@@ -1519,7 +1518,6 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
             Location::Pointer(ptr) => Ok(ptr.into()),
             Location::Function(_) => todo!(),
             Location::Argument(_) => todo!(),
-            Location::Temp(_, _) => todo!(),
             Location::ReturnPointer => todo!(),
             Location::Void => todo!(),
         }
@@ -1541,7 +1539,6 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
             }
             Location::Function(_) => todo!(),
             Location::Argument(_) => todo!(),
-            Location::Temp(_, _) => todo!(),
             Location::ReturnPointer => todo!(),
             Location::Void => todo!(),
         }

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -83,7 +83,6 @@ impl<'ctx> Location<'ctx> {
                 BasicValueEnum::PointerValue(ptr) => Ok(*ptr),
                 _ => Err(&LlvmBuilderError::CoerceValueIntoPointer),
             },
-            Location::Temp(_, _) => todo!(),
         }
         .map_err(|e| TransformerError::Internal(e))
     }
@@ -97,7 +96,6 @@ impl<'ctx> Location<'ctx> {
             Location::ReturnPointer => Err(&LlvmBuilderError::CoerceRetPtrIntoFn),
             Location::Void => Err(&LlvmBuilderError::CoerceVoidLocationIntoFunction),
             Location::Argument(_) => Err(&LlvmBuilderError::CoerceValueIntoFn),
-            Location::Temp(_, _) => todo!(),
         }
         .map_err(|e| TransformerError::Internal(e))
     }
@@ -718,12 +716,8 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
             Entry::Vacant(ve) => {
                 // and add a mapping from TempID to the pointer in the local var table
                 let loc = if let Ok(ty) = self.program.get_type(vd.ty())?.into_basic_type() {
-                    if ty.is_aggregate_type() {
-                        let ptr = self.program.builder.build_alloca(ty, &name);
-                        Location::Pointer(ptr)
-                    } else {
-                        Location::Temp(id, None)
-                    }
+                    let ptr = self.program.builder.build_alloca(ty, &name);
+                    Location::Pointer(ptr)
                 } else {
                     Location::Void
                 };
@@ -836,8 +830,6 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
             Location::Function(_) | Location::ReturnPointer | Location::Void => Err(
                 TransformerError::Internal(&LlvmBuilderError::ReadInvalidLocation),
             ),
-            Location::Temp(_, Some(val)) => Ok(val),
-            Location::Temp(_, None) => todo!(),
         }
     }
 
@@ -862,9 +854,6 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
             },
             Location::Void => (),
             Location::Argument(_) => panic!("Cannot store to an argument"),
-            Location::Temp(id, _) => {
-                self.temps.insert(id, Location::Temp(id, Some(r)));
-            }
         }
     }
 

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -635,14 +635,74 @@ mod mir2llvm_tests_visual {
 
     #[test]
     fn if_expr() {
-        compile_and_print_llvm(
+        let r: i64 = compile_and_run(
             "
-            fn test() {
-                let x: i64 := if (true) {2} else {3};
-                return;
+            fn run() -> i64 {
+                let a: i64 := test(true);
+                let b: i64 := test(false);
+
+                return a + b;
+            }
+
+            fn test(b: bool) -> i64 {
+                let mut y: i64 := 2;
+                let x: i64 := if (b) {mut y := 3; y} else {mut y:= 4; y};
+                return x;
             }
         ",
+            "main_run",
         );
+        assert_eq!(7, r);
+    }
+
+    #[test]
+    fn if_expr_nested() {
+        // This test is failing because of the ordering of the MIR BasicBlocks and the fact that the LLVM Builder
+        // follows the BB in the order of their IDs and not their partial order.  What this means is that, the
+        // BB where the temporary variable storing the result of hte inner expression is read is before any
+        // of the BBs where data is written to that temporary variable.  So the phi operation is not actually
+        // created.
+        //
+        // Why does this happen?  Can it be made so that the merge BB is always after the conditional BBs?
+        //
+        // One option might be to "linearize" the BB set while enforcing teh Partial Order. Then use _that_
+        // rather than whatever the constructed order is.  This will have the benefit of making the code less
+        // fragile: will not have to make sure that every where that BBs are created and added keeps the partial
+        // order.
+        let r: i64 = compile_and_run(
+            "
+            fn run() -> i64 {
+                let a: i64 := test(true, false);
+                let b: i64 := test(false, true);
+
+                return a + b;
+            }
+
+            fn test(b: bool, c: bool) -> i64 {
+                let mut y: i64 := 2;
+                let x: i64 := if (b) {
+                    if (c) {
+                        mut y := 3; 
+                        y
+                    } else {
+                        mut y := 4;
+                        y
+                    }
+                } else {
+                    if (c) {
+                        mut y := 5; 
+                        y
+                    } else {
+                        mut y := 6;
+                        y
+                    }
+                };
+                return x;
+            }
+        ",
+            "main_run",
+        );
+        assert_eq!(9, r);
     }
 
     #[test]

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -657,18 +657,6 @@ mod mir2llvm_tests_visual {
 
     #[test]
     fn if_expr_nested() {
-        // This test is failing because of the ordering of the MIR BasicBlocks and the fact that the LLVM Builder
-        // follows the BB in the order of their IDs and not their partial order.  What this means is that, the
-        // BB where the temporary variable storing the result of hte inner expression is read is before any
-        // of the BBs where data is written to that temporary variable.  So the phi operation is not actually
-        // created.
-        //
-        // Why does this happen?  Can it be made so that the merge BB is always after the conditional BBs?
-        //
-        // One option might be to "linearize" the BB set while enforcing teh Partial Order. Then use _that_
-        // rather than whatever the constructed order is.  This will have the benefit of making the code less
-        // fragile: will not have to make sure that every where that BBs are created and added keeps the partial
-        // order.
         let r: i64 = compile_and_run(
             "
             fn run() -> i64 {

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -661,9 +661,11 @@ mod mir2llvm_tests_visual {
             "
             fn run() -> i64 {
                 let a: i64 := test(true, false);
-                let b: i64 := test(false, true);
+                let b: i64 := test(true, true);
+                let c: i64 := test(false, true);
+                let d: i64 := test(false, false);
 
-                return a + b;
+                return a + b + c + d;
             }
 
             fn test(b: bool, c: bool) -> i64 {
@@ -690,7 +692,7 @@ mod mir2llvm_tests_visual {
         ",
             "main_run",
         );
-        assert_eq!(9, r);
+        assert_eq!(18, r);
     }
 
     #[test]


### PR DESCRIPTION
This reverts the change where Temp vars were bound to BasicValues rather than allocated space on the stack. That change created a bug for evaluating the resolved value of if expressions.  Fixing that bug would either require something like a dominance graph to determine a partial order of the BBs in a function so that the LLVM phi operator could be used, or, determining if a temp var has been written to more than once (and then allocating space for it).

While both these solutions are possible, they are not necessary for completion of this major task.  Therefore, the Temp var optimization is being reverted and will be done after the Mir2Llvm project is complete.