### PR TITLE
T79 mir2llvm imported functions

### DIFF
--- a/src/compiler/import.rs
+++ b/src/compiler/import.rs
@@ -23,14 +23,14 @@ pub struct ImportRoutineDef {
     path: Path,
 
     /// The parameter list of this routine
-    params: Vec<Type>,
+    params: Vec<(StringId, Type)>,
 
     /// The type that this routine resolves to
     ty: Type,
 }
 
 impl ImportRoutineDef {
-    pub fn new(path: Path, params: Vec<Type>, ty: Type) -> ImportRoutineDef {
+    pub fn new(path: Path, params: Vec<(StringId, Type)>, ty: Type) -> ImportRoutineDef {
         ImportRoutineDef { path, params, ty }
     }
 
@@ -40,7 +40,7 @@ impl ImportRoutineDef {
     }
 
     /// The parameter list of this routine
-    pub fn params(&self) -> &[Type] {
+    pub fn params(&self) -> &[(StringId, Type)] {
         &self.params
     }
 

--- a/src/compiler/llvm/llvmir.rs
+++ b/src/compiler/llvm/llvmir.rs
@@ -270,7 +270,10 @@ impl<'ctx> IrGen<'ctx> {
             for rd in &manifest.funcs {
                 self.add_fn_decl(
                     &rd.path().to_label(self.source_map, self.string_table),
-                    rd.params(),
+                    &rd.params()
+                        .iter()
+                        .map(|(_, ty)| ty.clone())
+                        .collect::<Vec<_>>(),
                     false,
                     rd.ty(),
                     Span::zero(),

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -946,7 +946,7 @@ mod mir2llvm_tests_visual {
     fn compile_and_print_llvm(text: &str) {
         let (sm, table, module) = compile(text);
         let mut project = MirProject::new();
-        transform::transform(&module, &mut project).unwrap();
+        transform::transform(&module, &[], &mut project).unwrap();
 
         println!("=== MIR ===:");
         println!("{}\n\n", project);
@@ -976,7 +976,7 @@ mod mir2llvm_tests_visual {
     fn compile_and_run<R: std::fmt::Debug>(text: &str, func_name: &str) -> R {
         let (sm, table, module) = compile(text);
         let mut project = MirProject::new();
-        transform::transform(&module, &mut project).unwrap();
+        transform::transform(&module, &[], &mut project).unwrap();
 
         println!("=== MIR ===:");
         println!("{}\n\n", project);

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -19,6 +19,7 @@ mod mir2llvm_tests_visual {
         compiler::{
             ast::{Module, MAIN_MODULE},
             diagnostics::Logger,
+            import::Import,
             lexer::{tokens::Token, LexerError},
             mir::{transform, MirProject, ProgramTraverser},
             parser::Parser,
@@ -39,7 +40,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -64,7 +65,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -81,7 +82,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -98,7 +99,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -115,7 +116,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -132,7 +133,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -147,7 +148,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -164,7 +165,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -181,7 +182,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -198,7 +199,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -215,7 +216,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -229,7 +230,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -250,7 +251,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -287,7 +288,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -324,7 +325,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -338,7 +339,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -352,7 +353,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -367,7 +368,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -382,7 +383,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -397,7 +398,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -412,7 +413,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -426,7 +427,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -440,7 +441,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -454,7 +455,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -468,7 +469,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -484,7 +485,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -498,7 +499,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -511,7 +512,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -529,7 +530,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -543,7 +544,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -557,7 +558,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -572,7 +573,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -586,7 +587,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -600,7 +601,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -614,7 +615,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -630,7 +631,7 @@ mod mir2llvm_tests_visual {
             }
         ";
 
-        compile_and_print_llvm(text);
+        compile_and_print_llvm(text, &[]);
     }
 
     #[test]
@@ -734,6 +735,7 @@ mod mir2llvm_tests_visual {
                 return x;
             }
         ",
+            &[],
         );
     }
 
@@ -754,6 +756,7 @@ mod mir2llvm_tests_visual {
                 }
             }
         ",
+            &[],
         );
     }
 
@@ -771,6 +774,7 @@ mod mir2llvm_tests_visual {
                 return;
             }
         ",
+            &[],
         );
     }
 
@@ -786,6 +790,7 @@ mod mir2llvm_tests_visual {
                 return 5.0;
             }
         ",
+            &[],
         );
     }
 
@@ -815,6 +820,7 @@ mod mir2llvm_tests_visual {
                 return 5;
             }
         ",
+            &[],
         );
     }
 
@@ -844,6 +850,7 @@ mod mir2llvm_tests_visual {
                 return arr[0];
             }
         ",
+            &[],
         );
     }
 
@@ -855,6 +862,7 @@ mod mir2llvm_tests_visual {
                 return [1, 2];
             }
         ",
+            &[],
         );
     }
 
@@ -866,6 +874,7 @@ mod mir2llvm_tests_visual {
                 return a;
             }
         ",
+            &[],
         );
     }
 
@@ -882,6 +891,7 @@ mod mir2llvm_tests_visual {
                 return [1, 2];
             }
         ",
+            &[],
         );
     }
 
@@ -943,10 +953,10 @@ mod mir2llvm_tests_visual {
 
     type LResult = std::result::Result<Vec<Token>, CompilerError<LexerError>>;
 
-    fn compile_and_print_llvm(text: &str) {
+    fn compile_and_print_llvm(text: &str, imports: &[Import]) {
         let (sm, table, module) = compile(text);
         let mut project = MirProject::new();
-        transform::transform(&module, &[], &mut project).unwrap();
+        transform::transform(&module, imports, &mut project).unwrap();
 
         println!("=== MIR ===:");
         println!("{}\n\n", project);

--- a/src/compiler/mir/project.rs
+++ b/src/compiler/mir/project.rs
@@ -201,6 +201,8 @@ impl StaticDefinitions {
         Some(DefId::new(pos as u32))
     }
 
+    /// Given a [`StringId`] return its static memory [`DefId`], if the [`StringId`]
+    /// is not in the static memory abstraction then this will return [`None`].
     fn find_string_literal(&self, id: StringId) -> Option<DefId> {
         let pos = self.defs.iter().position(|i| match i {
             StaticItem::Function(_) => false,

--- a/src/compiler/mir/test.rs
+++ b/src/compiler/mir/test.rs
@@ -68,7 +68,7 @@ pub mod tests {
             let mut table = StringTable::new();
             let module = compile(text, &mut table);
             let mut project = MirProject::new();
-            transform::transform(&module, &mut project).unwrap();
+            transform::transform(&module, &[], &mut project).unwrap();
             println!("{}", project);
         }
 
@@ -89,7 +89,7 @@ pub mod tests {
             let mut table = StringTable::new();
             let module = compile(text, &mut table);
             let mut project = MirProject::new();
-            transform::transform(&module, &mut project).unwrap();
+            transform::transform(&module, &[], &mut project).unwrap();
             println!("{}", project);
         }
 
@@ -108,7 +108,7 @@ pub mod tests {
             let mut table = StringTable::new();
             let module = compile(text, &mut table);
             let mut project = MirProject::new();
-            transform::transform(&module, &mut project).unwrap();
+            transform::transform(&module, &[], &mut project).unwrap();
             println!("{}", project);
         }
 
@@ -127,7 +127,7 @@ pub mod tests {
             let mut table = StringTable::new();
             let module = compile(text, &mut table);
             let mut project = MirProject::new();
-            transform::transform(&module, &mut project).unwrap();
+            transform::transform(&module, &[], &mut project).unwrap();
             println!("{}", project);
         }
 
@@ -144,7 +144,7 @@ pub mod tests {
             let mut table = StringTable::new();
             let module = compile(text, &mut table);
             let mut project = MirProject::new();
-            transform::transform(&module, &mut project).unwrap();
+            transform::transform(&module, &[], &mut project).unwrap();
             println!("{}", project);
         }
 
@@ -161,7 +161,7 @@ pub mod tests {
             let mut table = StringTable::new();
             let module = compile(text, &mut table);
             let mut project = MirProject::new();
-            transform::transform(&module, &mut project).unwrap();
+            transform::transform(&module, &[], &mut project).unwrap();
             println!("{}", project);
         }
 
@@ -180,7 +180,7 @@ pub mod tests {
             let mut table = StringTable::new();
             let module = compile(text, &mut table);
             let mut project = MirProject::new();
-            transform::transform(&module, &mut project).unwrap();
+            transform::transform(&module, &[], &mut project).unwrap();
             println!("{}", project);
         }
 
@@ -195,7 +195,7 @@ pub mod tests {
             let mut table = StringTable::new();
             let module = compile(text, &mut table);
             let mut project = MirProject::new();
-            transform::transform(&module, &mut project).unwrap();
+            transform::transform(&module, &[], &mut project).unwrap();
             println!("{}", project);
         }
 
@@ -214,7 +214,7 @@ pub mod tests {
             let mut table = StringTable::new();
             let module = compile(text, &mut table);
             let mut project = MirProject::new();
-            transform::transform(&module, &mut project).unwrap();
+            transform::transform(&module, &[], &mut project).unwrap();
             println!("{}", project);
         }
 
@@ -237,7 +237,7 @@ pub mod tests {
             let mut table = StringTable::new();
             let module = compile(text, &mut table);
             let mut project = MirProject::new();
-            transform::transform(&module, &mut project).unwrap();
+            transform::transform(&module, &[], &mut project).unwrap();
             println!("{}", project);
         }
 
@@ -254,7 +254,7 @@ pub mod tests {
             let mut table = StringTable::new();
             let module = compile(text, &mut table);
             let mut project = MirProject::new();
-            transform::transform(&module, &mut project).unwrap();
+            transform::transform(&module, &[], &mut project).unwrap();
             println!("{}", project);
         }
 
@@ -274,7 +274,7 @@ pub mod tests {
             let mut table = StringTable::new();
             let module = compile(text, &mut table);
             let mut project = MirProject::new();
-            transform::transform(&module, &mut project).unwrap();
+            transform::transform(&module, &[], &mut project).unwrap();
             println!("{}", project);
         }
     }
@@ -290,7 +290,7 @@ pub mod tests {
         let mut table = StringTable::new();
         let module = compile(text, &mut table);
         let mut project = MirProject::new();
-        transform::transform(&module, &mut project).unwrap();
+        transform::transform(&module, &[], &mut project).unwrap();
 
         let path: Path = to_path(&["main", "test"], &table);
         let def_id = project.find_def(&path).unwrap();
@@ -338,7 +338,7 @@ pub mod tests {
         let mut table = StringTable::new();
         let module = compile(text, &mut table);
         let mut project = MirProject::new();
-        transform::transform(&module, &mut project).unwrap();
+        transform::transform(&module, &[], &mut project).unwrap();
 
         let path: Path = to_path(&["main", "test"], &table);
         let def_id = project.find_def(&path).unwrap();
@@ -372,7 +372,7 @@ pub mod tests {
         let mut table = StringTable::new();
         let module = compile(text, &mut table);
         let mut project = MirProject::new();
-        transform::transform(&module, &mut project).unwrap();
+        transform::transform(&module, &[], &mut project).unwrap();
 
         let path: Path = to_path(&["main", "test"], &table);
         let def_id = project.find_def(&path).unwrap();
@@ -433,7 +433,7 @@ pub mod tests {
                 );
                 let module = compile(&text, &mut table);
                 let mut project = MirProject::new();
-                transform::transform(&module, &mut project).unwrap();
+                transform::transform(&module, &[], &mut project).unwrap();
 
                 let path: Path = to_path(&["main", "test"], &table);
                 let def_id = project.find_def(&path).unwrap();
@@ -489,7 +489,7 @@ pub mod tests {
                 );
                 let module = compile(&text, &mut table);
                 let mut project = MirProject::new();
-                transform::transform(&module, &mut project).unwrap();
+                transform::transform(&module, &[], &mut project).unwrap();
 
                 let path: Path = to_path(&["main", "test"], &table);
                 let def_id = project.find_def(&path).unwrap();
@@ -548,7 +548,7 @@ pub mod tests {
             );
             let module = compile(&text, &mut table);
             let mut project = MirProject::new();
-            transform::transform(&module, &mut project).unwrap();
+            transform::transform(&module, &[], &mut project).unwrap();
 
             let path: Path = to_path(&["main", "test"], &table);
             let def_id = project.find_def(&path).unwrap();
@@ -643,7 +643,7 @@ pub mod tests {
                 );
                 let module = compile(&text, &mut table);
                 let mut project = MirProject::new();
-                transform::transform(&module, &mut project).unwrap();
+                transform::transform(&module, &[], &mut project).unwrap();
 
                 let path: Path = to_path(&["main", "test"], &table);
                 let def_id = project.find_def(&path).unwrap();
@@ -714,7 +714,7 @@ pub mod tests {
             );
             let module = compile(&text, &mut table);
             let mut project = MirProject::new();
-            transform::transform(&module, &mut project).unwrap();
+            transform::transform(&module, &[], &mut project).unwrap();
 
             let path: Path = to_path(&["main", "test"], &table);
             let def_id = project.find_def(&path).unwrap();
@@ -760,7 +760,7 @@ pub mod tests {
                 );
                 let module = compile(&text, &mut table);
                 let mut project = MirProject::new();
-                transform::transform(&module, &mut project).unwrap();
+                transform::transform(&module, &[], &mut project).unwrap();
 
                 let path: Path = to_path(&["main", "test"], &table);
                 let def_id = project.find_def(&path).unwrap();
@@ -810,7 +810,7 @@ pub mod tests {
             );
             let module = compile(&text, &mut table);
             let mut project = MirProject::new();
-            transform::transform(&module, &mut project).unwrap();
+            transform::transform(&module, &[], &mut project).unwrap();
 
             let path: Path = to_path(&["main", "test"], &table);
             let def_id = project.find_def(&path).unwrap();
@@ -864,7 +864,7 @@ pub mod tests {
             );
             let module = compile(&text, &mut table);
             let mut project = MirProject::new();
-            transform::transform(&module, &mut project).unwrap();
+            transform::transform(&module, &[], &mut project).unwrap();
 
             let path: Path = to_path(&["main", "test"], &table);
             let def_id = project.find_def(&path).unwrap();
@@ -892,7 +892,7 @@ pub mod tests {
         let mut table = StringTable::new();
         let module = compile(text, &mut table);
         let mut project = MirProject::new();
-        transform::transform(&module, &mut project).unwrap();
+        transform::transform(&module, &[], &mut project).unwrap();
 
         let path: Path = to_path(&["main", "test"], &table);
         let def_id = project.find_def(&path).unwrap();
@@ -936,7 +936,7 @@ pub mod tests {
         let mut table = StringTable::new();
         let module = compile(text, &mut table);
         let mut project = MirProject::new();
-        transform::transform(&module, &mut project).unwrap();
+        transform::transform(&module, &[], &mut project).unwrap();
 
         let path: Path = to_path(&["main", "test"], &table);
         let def_id = project.find_def(&path).unwrap();
@@ -992,7 +992,7 @@ pub mod tests {
         let mut table = StringTable::new();
         let module = compile(text, &mut table);
         let mut project = MirProject::new();
-        transform::transform(&module, &mut project).unwrap();
+        transform::transform(&module, &[], &mut project).unwrap();
 
         let path: Path = to_path(&["main", "test"], &table);
         let def_id = project.find_def(&path).unwrap();
@@ -1045,7 +1045,7 @@ pub mod tests {
         let module = compile(text, &mut table);
 
         let mut project = MirProject::new();
-        transform::transform(&module, &mut project).unwrap();
+        transform::transform(&module, &[], &mut project).unwrap();
 
         let path: Path = to_path(&["main", "test"], &table);
         let def_id = project.find_def(&path).unwrap();
@@ -1097,7 +1097,7 @@ pub mod tests {
         let module = compile(text, &mut table);
 
         let mut project = MirProject::new();
-        transform::transform(&module, &mut project).unwrap();
+        transform::transform(&module, &[], &mut project).unwrap();
 
         let path: Path = to_path(&["main", "test"], &table);
         let def_id = project.find_def(&path).unwrap();
@@ -1157,7 +1157,7 @@ pub mod tests {
         let module = compile(text, &mut table);
 
         let mut project = MirProject::new();
-        transform::transform(&module, &mut project).unwrap();
+        transform::transform(&module, &[], &mut project).unwrap();
 
         let path: Path = to_path(&["main", "test"], &table);
         let def_id = project.find_def(&path).unwrap();
@@ -1189,7 +1189,7 @@ pub mod tests {
         let module = compile(text, &mut table);
 
         let mut project = MirProject::new();
-        transform::transform(&module, &mut project).unwrap();
+        transform::transform(&module, &[], &mut project).unwrap();
 
         let path: Path = to_path(&["main", "test"], &table);
         let def_id = project.find_def(&path).unwrap();
@@ -1241,7 +1241,7 @@ pub mod tests {
         let module = compile(text, &mut table);
 
         let mut project = MirProject::new();
-        transform::transform(&module, &mut project).unwrap();
+        transform::transform(&module, &[], &mut project).unwrap();
 
         let path: Path = to_path(&["main", "test"], &table);
         let def_id = project.find_def(&path).unwrap();
@@ -1289,7 +1289,7 @@ pub mod tests {
         let module = compile(text, &mut table);
 
         let mut project = MirProject::new();
-        transform::transform(&module, &mut project).unwrap();
+        transform::transform(&module, &[], &mut project).unwrap();
 
         let path: Path = to_path(&["main", "test"], &table);
         let expected_target = project.find_def(&path).unwrap();
@@ -1334,7 +1334,7 @@ pub mod tests {
         let module = compile(text, &mut table);
 
         let mut project = MirProject::new();
-        transform::transform(&module, &mut project).unwrap();
+        transform::transform(&module, &[], &mut project).unwrap();
 
         let path: Path = to_path(&["main", "test"], &table);
         let def_id = project.find_def(&path).unwrap();
@@ -1383,7 +1383,7 @@ pub mod tests {
         let module = compile(text, &mut table);
 
         let mut project = MirProject::new();
-        transform::transform(&module, &mut project).unwrap();
+        transform::transform(&module, &[], &mut project).unwrap();
 
         let path: Path = to_path(&["main", "test"], &table);
         let def_id = project.find_def(&path).unwrap();
@@ -1435,7 +1435,7 @@ pub mod tests {
         let mut table = StringTable::new();
         let module = compile(text, &mut table);
         let mut project = MirProject::new();
-        transform::transform(&module, &mut project).unwrap();
+        transform::transform(&module, &[], &mut project).unwrap();
 
         let path: Path = to_path(&["main", "test"], &table);
         let def_id = project.find_def(&path).unwrap();
@@ -1473,7 +1473,7 @@ pub mod tests {
         let module = compile(text, &mut table);
 
         let mut project = MirProject::new();
-        transform::transform(&module, &mut project).unwrap();
+        transform::transform(&module, &[], &mut project).unwrap();
 
         let path: Path = to_path(&["main", "test"], &table);
         let def_id = project.find_def(&path).unwrap();

--- a/src/compiler/mir/transform/error.rs
+++ b/src/compiler/mir/transform/error.rs
@@ -6,6 +6,7 @@ use crate::compiler::mir::{project::StaticDefinitionError, typetable::TypeTableE
 pub enum TransformError {
     TypeError(TypeTableError),
     StaticDefError(StaticDefinitionError),
+    TypeNotFound,
 }
 
 impl From<TypeTableError> for TransformError {

--- a/src/compiler/mir/transform/module.rs
+++ b/src/compiler/mir/transform/module.rs
@@ -144,31 +144,36 @@ fn add_fn_declarations(
 
     for f in funcs {
         // convert args into MIR args
-        let args: Vec<_> = f
-            .params
-            .iter()
-            .map(|p| {
-                let ty = project
-                    .find_type(p.context().ty())
-                    .expect("Cannot find type in Project");
-                ArgDecl::new(p.name, ty, None, p.context().span())
-            })
-            .collect();
-
-        let ret_ty = project
-            .find_type(f.context().ty())
-            .expect("Cannot find return type");
-
-        let p = Procedure::new(
-            f.context().canonical_path(),
-            args,
-            ret_ty,
-            f.context().span(),
-        );
-        project.add_func(p)?;
+        let decl = create_fn_declaration(f, project);
+        project.add_func(decl)?;
     }
 
     Ok(())
+}
+
+fn create_fn_declaration(f: &RoutineDef<SemanticContext>, project: &MirProject) -> Procedure {
+    // convert args into MIR args
+    let args: Vec<_> = f
+        .params
+        .iter()
+        .map(|p| {
+            let ty = project
+                .find_type(p.context().ty())
+                .expect("Cannot find type in Project");
+            ArgDecl::new(p.name, ty, None, p.context().span())
+        })
+        .collect();
+
+    let ret_ty = project
+        .find_type(f.context().ty())
+        .expect("Cannot find return type");
+
+    Procedure::new(
+        f.context().canonical_path(),
+        args,
+        ret_ty,
+        f.context().span(),
+    )
 }
 
 fn transform_fns(

--- a/src/compiler/mir/transform/module.rs
+++ b/src/compiler/mir/transform/module.rs
@@ -162,11 +162,13 @@ fn add_import_function(
         .iter()
         .map(|p| {
             //    iterate through each param and convert the type to a TypeId
-            let ty = project.find_type(p).ok_or(TransformError::TypeNotFound)?;
+            let ty = project
+                .find_type(&p.1)
+                .ok_or(TransformError::TypeNotFound)?;
 
             //    Create a name for the parameter (names are not included in the manifeset :O )
             //    Generate an ArgDecl
-            Ok(ArgDecl::new(StringId::new(), ty, None, Span::zero()))
+            Ok(ArgDecl::new(p.0, ty, None, Span::zero()))
         })
         .collect::<Result<Vec<_>, TransformError>>()?;
 

--- a/src/compiler/mir/transform/module.rs
+++ b/src/compiler/mir/transform/module.rs
@@ -166,7 +166,7 @@ fn add_import_declarations(
             .ok_or(TransformError::TypeNotFound)?;
 
         // Create a Procedure
-        let p = Procedure::new(f.path(), args, ret_ty, Span::zero());
+        let p = Procedure::new_extern(f.path(), args, false, ret_ty, Span::zero());
 
         // Add procedure to project
         project.add_func(p)?;

--- a/src/compiler/semantics/stack.rs
+++ b/src/compiler/semantics/stack.rs
@@ -73,7 +73,11 @@ impl<'a> SymbolTableScopeStack {
                 debug!("Import function {}", imp_routine.path());
                 self.import_function(
                     imp_routine.path().clone(),
-                    imp_routine.params().into(),
+                    imp_routine
+                        .params()
+                        .iter()
+                        .map(|(_, ty)| ty.clone())
+                        .collect(),
                     imp_routine.ty().clone(),
                 );
             }

--- a/src/project/manifest.rs
+++ b/src/project/manifest.rs
@@ -98,7 +98,7 @@ struct ManifestRoutineDef {
     name: String,
     canon_path: String,
     def: ManifestRoutineDefType,
-    params: Vec<ManifestType>,
+    params: Vec<(String, ManifestType)>,
     ret_ty: ManifestType,
 }
 
@@ -112,7 +112,12 @@ impl ManifestRoutineDef {
         let params = rd
             .params
             .iter()
-            .map(|p| ManifestType::from_ty(sm, st, &p.ty))
+            .map(|p| {
+                Ok((
+                    st.get(p.name().unwrap()).unwrap(),
+                    ManifestType::from_ty(sm, st, &p.ty)?,
+                ))
+            })
             .collect::<Result<_, ManifestError>>()?;
         let def = ManifestRoutineDefType::from_def(rd.def);
         let ret_ty = ManifestType::from_ty(sm, st, &rd.ret_ty)?;
@@ -132,7 +137,7 @@ impl ManifestRoutineDef {
         let params = self
             .params
             .iter()
-            .map(|p| p.to_ty(st))
+            .map(|p| Ok((st.insert(p.0.clone()), p.1.to_ty(st)?)))
             .collect::<Result<_, ManifestError>>()?;
         let ret_ty = self.ret_ty.to_ty(st)?;
 


### PR DESCRIPTION
This adds support for importing functions from Import Manifests and adding them to the MIR project and compiling them into LLVM.