### PR TITLE
T145 mir2llvm array in struct of struct failing

### DIFF
--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -449,6 +449,7 @@ impl<'p, 'module, 'ctx>
     fn add_type(&mut self, id: TypeId, ty: &MirTypeDef) -> Result<(), TransformerError> {
         debug!("Adding a type to the Module");
 
+        // Do not attempt to add the Null type to the LLVM IR table
         match ty {
             MirTypeDef::Base(MirBaseType::Null) => return Ok(()),
             _ => (),

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -440,15 +440,17 @@ impl<'p, 'module, 'ctx>
     fn add_type(&mut self, id: TypeId, ty: &MirTypeDef) -> Result<(), TransformerError> {
         debug!("Adding a type to the Module");
 
-        let previous_value = ty
-            .into_basic_type_enum(self)
-            .and_then(|llvm_ty| self.ty_table.insert(id, llvm_ty));
-
-        // If `insert` returns `None` then it means there was no previous value associated with `id`
-        // otherwise, `id` was already defined and this should thrown an error.
-        match previous_value {
-            None => Ok(()),
-            Some(_) => Err(TransformerError::TypeAlreadyDefined),
+        // If type is already in the table then skip
+        if self.ty_table.contains_key(&id) {
+            Ok(())
+        } else {
+            match ty.into_basic_type_enum(self) {
+                Some(llvm_ty) => {
+                    self.ty_table.insert(id, llvm_ty);
+                    Ok(())
+                }
+                None => Ok(()),
+            }
         }
     }
 

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -482,13 +482,6 @@ impl<'p, 'module, 'ctx>
         }
     }
 
-    fn add_types(&mut self, types: &TypeTable) -> Result<(), TransformerError> {
-        // Add stubs for all structures
-        // Add all primitive types
-        //
-        todo!()
-    }
-
     fn get_function_transformer(
         &'p self,
         id: DefId,

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -457,20 +457,21 @@ impl<'p, 'module, 'ctx>
                     MirStructDef::Defined(fields) => {
                         // Get the structure declaration
                         let s = self.ty_table.get_mut(&id).unwrap().into_struct_type();
+
                         // Add fields to structure definition
                         let field_types: Vec<_> = fields
                             .iter()
                             .map(|f| self.get_type(f.ty).unwrap().into_basic_type().unwrap())
                             .collect();
                         s.set_body(&field_types, false);
+                        Ok(())
                     }
-                    MirStructDef::Declared => (),
+                    MirStructDef::Declared => Err(TransformerError::StructUndefined),
                 },
-                MirTypeDef::Base(_) => (),
-                MirTypeDef::Array { ty, sz } => (),
-                MirTypeDef::RawPointer { mutable, target } => (),
+                MirTypeDef::Base(_) | MirTypeDef::Array { .. } | MirTypeDef::RawPointer { .. } => {
+                    Err(TransformerError::TypeAlreadyDefined)
+                }
             }
-            Err(TransformerError::TypeAlreadyDefined)
         } else {
             match ty.into_basic_type_enum(self) {
                 Some(llvm_ty) => {

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -18,7 +18,7 @@ use crate::{
         ast::Path,
         mir::{
             ir::*, DefId, FieldId, FunctionBuilder, MirBaseType, MirStructDef, MirTypeDef,
-            ProgramBuilder, TransformerError, TransformerInternalError, TypeId, TypeTable,
+            ProgramBuilder, TransformerError, TransformerInternalError, TypeId,
         },
         CompilerDisplay, SourceMap, Span,
     },

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -520,7 +520,9 @@ impl MirTypeDef {
                     .iter()
                     .map(|f| {
                         p.get_type(f.ty)
-                            .expect("Cannot find given Type ID")
+                            .unwrap_or_else(|e| {
+                                panic!("Cannot find given Type ID {:?} in\n{:?}", e, p.ty_table)
+                            })
                             .into_basic_type()
                             .expect("Cannot convert to a basic type")
                     })

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -554,6 +554,9 @@ impl MirTypeDef {
                     .map(|f| {
                         p.get_type(f.ty)
                             .unwrap_or_else(|e| {
+                                // This panics because by this time, every type that is referenced in this structure
+                                // should already be added (or declared).  So, this means that a bug exists either in
+                                // this module or in the MIR Traverser
                                 panic!("Cannot find given Type ID {:?} in\n{:?}", e, p.ty_table)
                             })
                             .into_basic_type()

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -478,7 +478,7 @@ impl<'p, 'module, 'ctx>
                     self.ty_table.insert(id, llvm_ty);
                     Ok(())
                 }
-                None => Ok(()),
+                None => panic!("Attempting to use Null as a type"),
             }
         }
     }

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -442,7 +442,7 @@ impl<'p, 'module, 'ctx>
 
         // If type is already in the table then skip
         if self.ty_table.contains_key(&id) {
-            Ok(())
+            Err(TransformerError::TypeAlreadyDefined)
         } else {
             match ty.into_basic_type_enum(self) {
                 Some(llvm_ty) => {

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -503,6 +503,19 @@ mod mir2llvm_tests_visual {
     }
 
     #[test]
+    fn self_reference_struct() {
+        let text = "
+            struct S {ptr: *const S}
+
+            fn test(a: S) {
+                return;
+            }
+        ";
+
+        compile_and_print_llvm(text, &[], &[]);
+    }
+
+    #[test]
     fn simple_array_expression() {
         let text = "
             fn test() {

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -516,6 +516,33 @@ mod mir2llvm_tests_visual {
     }
 
     #[test]
+    fn self_reference_struct_indirect() {
+        let text = "
+            struct S {s: S2, ptr: *mut S2}
+            struct S2 {ptr: *const S}
+
+            fn test(a: S) {
+                return;
+            }
+        ";
+
+        compile_and_print_llvm(text, &[], &[]);
+    }
+
+    #[test]
+    fn self_reference_struct_pointer_to_pointer() {
+        let text = "
+            struct S {ptr: *const *const S}
+
+            fn test(a: S) {
+                return;
+            }
+        ";
+
+        compile_and_print_llvm(text, &[], &[]);
+    }
+
+    #[test]
     fn simple_array_expression() {
         let text = "
             fn test() {

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -548,6 +548,27 @@ mod mir2llvm_tests_visual {
     }
 
     #[test]
+    fn array_in_struct_expression() {
+        let text = "
+            fn test() -> i64 {
+                let s2: S2 := S2{x: [S{ x:[1, 2]}, S{x: [3, 4]}]};
+
+                return s2.x[0].x[0];
+            }
+
+            struct S {
+                x: [i64;2],
+            }
+
+            struct S2 {
+                x: [S; 2],
+            }
+        ";
+
+        compile_and_print_llvm(text, &[], &[]);
+    }
+
+    #[test]
     fn struct_expression() {
         let text = "
             struct S {a: i64, b: f64}

--- a/src/compiler/mir/mod.rs
+++ b/src/compiler/mir/mod.rs
@@ -26,7 +26,7 @@ pub use ops::{
     FunctionBuilder, ProgramBuilder, ProgramTraverser, TransformerError, TransformerInternalError,
 };
 pub use project::{DefId, MirProject};
-pub use typetable::{FieldId, MirBaseType, MirStructDef, MirTypeDef, TypeId, TypeTable};
+pub use typetable::{FieldId, MirBaseType, MirStructDef, MirTypeDef, TypeId};
 
 // Unit test modules
 #[cfg(test)]

--- a/src/compiler/mir/mod.rs
+++ b/src/compiler/mir/mod.rs
@@ -26,7 +26,7 @@ pub use ops::{
     FunctionBuilder, ProgramBuilder, ProgramTraverser, TransformerError, TransformerInternalError,
 };
 pub use project::{DefId, MirProject};
-pub use typetable::{FieldId, MirBaseType, MirStructDef, MirTypeDef, TypeId};
+pub use typetable::{FieldId, MirBaseType, MirStructDef, MirTypeDef, TypeId, TypeTable};
 
 // Unit test modules
 #[cfg(test)]

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -21,7 +21,12 @@ use std::{collections::VecDeque, fmt::Debug};
 use crate::{
     compiler::{
         ast::Path,
-        mir::{ir::*, project::DefId, typetable::FieldId, MirTypeDef, TypeId},
+        mir::{
+            ir::*,
+            project::DefId,
+            typetable::{FieldId, TypeTable},
+            MirTypeDef, TypeId,
+        },
         Span,
     },
     StringId,
@@ -40,7 +45,10 @@ pub trait ProgramBuilder<'p, L, V, F: FunctionBuilder<L, V>> {
         ret_ty: TypeId,
     ) -> Result<(), TransformerError>;
 
+    fn declare_struct(&mut self, id: TypeId, path: &Path) -> Result<(), TransformerError>;
     fn add_type(&mut self, id: TypeId, ty: &MirTypeDef) -> Result<(), TransformerError>;
+
+    fn add_types(&mut self, types: &TypeTable) -> Result<(), TransformerError>;
 
     /// Creates a new transformer for the given function
     fn get_function_transformer(&'p self, func_id: DefId) -> Result<F, TransformerError>;

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -21,12 +21,7 @@ use std::{collections::VecDeque, fmt::Debug};
 use crate::{
     compiler::{
         ast::Path,
-        mir::{
-            ir::*,
-            project::DefId,
-            typetable::{FieldId, TypeTable},
-            MirTypeDef, TypeId,
-        },
+        mir::{ir::*, project::DefId, typetable::FieldId, MirTypeDef, TypeId},
         Span,
     },
     StringId,

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -48,8 +48,6 @@ pub trait ProgramBuilder<'p, L, V, F: FunctionBuilder<L, V>> {
     fn declare_struct(&mut self, id: TypeId, path: &Path) -> Result<(), TransformerError>;
     fn add_type(&mut self, id: TypeId, ty: &MirTypeDef) -> Result<(), TransformerError>;
 
-    fn add_types(&mut self, types: &TypeTable) -> Result<(), TransformerError>;
-
     /// Creates a new transformer for the given function
     fn get_function_transformer(&'p self, func_id: DefId) -> Result<F, TransformerError>;
 }

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -273,6 +273,7 @@ pub enum TransformerError {
     FunctionAlreadyDeclared,
     FunctionNotFound,
     TypeAlreadyDefined,
+    StructUndefined,
     TypeNotFound(TypeId),
     ArgNotFound,
     Internal(&'static dyn TransformerInternalError),

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -5,7 +5,7 @@ use std::{collections::VecDeque, marker::PhantomData};
 
 use log::debug;
 
-use crate::compiler::mir::{ir::*, MirProject, MirTypeDef};
+use crate::compiler::mir::{ir::*, MirProject, MirStructDef, MirTypeDef};
 
 use super::{transformer::FunctionBuilder, ProgramBuilder};
 
@@ -71,8 +71,8 @@ impl<'a> ProgramTraverser<'a> {
                 self.map_type(*target, self.mir.get_type(*target), xfmr)
             }
             MirTypeDef::Structure { def, .. } => match def {
-                crate::compiler::mir::MirStructDef::Declared => todo!(),
-                crate::compiler::mir::MirStructDef::Defined(fields) => fields
+                MirStructDef::Declared => todo!(),
+                MirStructDef::Defined(fields) => fields
                     .iter()
                     .for_each(|field| self.map_type(field.ty, self.mir.get_type(field.ty), xfmr)),
             },

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -5,7 +5,7 @@ use std::{collections::VecDeque, marker::PhantomData};
 
 use log::debug;
 
-use crate::compiler::mir::{ir::*, MirProject};
+use crate::compiler::mir::{ir::*, MirProject, MirTypeDef};
 
 use super::{transformer::FunctionBuilder, ProgramBuilder};
 
@@ -59,20 +59,18 @@ impl<'a> ProgramTraverser<'a> {
     fn map_type<'p, L, V, F: FunctionBuilder<L, V>, P: ProgramBuilder<'p, L, V, F>>(
         &self,
         id: crate::compiler::mir::TypeId,
-        ty: &crate::compiler::mir::MirTypeDef,
+        ty: &MirTypeDef,
         xfmr: &mut P,
     ) {
         debug!("Traversing types");
 
         match ty {
-            crate::compiler::mir::MirTypeDef::Base(_) => (),
-            crate::compiler::mir::MirTypeDef::Array { ty, .. } => {
-                self.map_type(*ty, self.mir.get_type(*ty), xfmr)
-            }
-            crate::compiler::mir::MirTypeDef::RawPointer { target, .. } => {
+            MirTypeDef::Base(_) => (),
+            MirTypeDef::Array { ty, .. } => self.map_type(*ty, self.mir.get_type(*ty), xfmr),
+            MirTypeDef::RawPointer { target, .. } => {
                 self.map_type(*target, self.mir.get_type(*target), xfmr)
             }
-            crate::compiler::mir::MirTypeDef::Structure { def, .. } => match def {
+            MirTypeDef::Structure { def, .. } => match def {
                 crate::compiler::mir::MirStructDef::Declared => todo!(),
                 crate::compiler::mir::MirStructDef::Defined(fields) => fields
                     .iter()

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -31,9 +31,7 @@ impl<'a> ProgramTraverser<'a> {
         debug!("Applying given Transformer to MIR");
 
         // Add every type in the type table to the project
-        for (id, ty) in self.mir.type_iter() {
-            xfmr.add_type(id, ty).unwrap()
-        }
+        self.map_types(xfmr);
 
         // Declare every function in the ProgramTransformer
         for (id, f) in self.mir.function_iter() {
@@ -52,6 +50,18 @@ impl<'a> ProgramTraverser<'a> {
             // Create function traverser and pass it the transformer
             let mut traverser = FunctionTraverser::new(self.mir, f, &mut fn_xfm);
             traverser.map();
+        }
+    }
+
+    fn map_types<'p, L, V, F: FunctionBuilder<L, V>, P: ProgramBuilder<'p, L, V, F>>(
+        &self,
+        xfmr: &mut P,
+    ) {
+        debug!("Traversing types");
+
+        // Add every type in the type table to the project
+        for (id, ty) in self.mir.type_iter() {
+            xfmr.add_type(id, ty).unwrap()
         }
     }
 }

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -88,7 +88,7 @@ impl<'a> ProgramTraverser<'a> {
                 }
             }
             MirTypeDef::Structure { def, .. } => match def {
-                MirStructDef::Declared => todo!(),
+                MirStructDef::Declared => panic!("Attempting to convert Undefined structure"),
                 MirStructDef::Defined(fields) => {
                     for field in fields {
                         self.map_type(field.ty, self.mir.get_type(field.ty), xfmr)?

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -30,7 +30,15 @@ impl<'a> ProgramTraverser<'a> {
     ) {
         debug!("Applying given Transformer to MIR");
 
-        // Add every type in the type table to the project
+        // Declare every structure, but do not define the structures yet.
+        // This solves the problem of structures with reference cycles
+        for (id, ty) in self.mir.type_iter() {
+            match ty {
+                MirTypeDef::Structure { path, .. } => xfmr.declare_struct(id, path).unwrap(),
+                _ => (),
+            }
+        }
+
         // Add every type in the type table to the project
         for (id, ty) in self.mir.type_iter() {
             self.map_type(id, ty, xfmr);
@@ -68,7 +76,8 @@ impl<'a> ProgramTraverser<'a> {
             MirTypeDef::Base(_) => (),
             MirTypeDef::Array { ty, .. } => self.map_type(*ty, self.mir.get_type(*ty), xfmr),
             MirTypeDef::RawPointer { target, .. } => {
-                self.map_type(*target, self.mir.get_type(*target), xfmr)
+                //self.map_type(*target, self.mir.get_type(*target), xfmr)
+                ()
             }
             MirTypeDef::Structure { def, .. } => match def {
                 MirStructDef::Declared => todo!(),

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -5,7 +5,7 @@ use std::{collections::VecDeque, marker::PhantomData};
 
 use log::debug;
 
-use crate::compiler::mir::{ir::*, MirProject, MirStructDef, MirTypeDef};
+use crate::compiler::mir::{ir::*, MirProject, MirStructDef, MirTypeDef, TypeId};
 
 use super::{transformer::FunctionBuilder, ProgramBuilder};
 
@@ -32,6 +32,7 @@ impl<'a> ProgramTraverser<'a> {
 
         // Declare every structure, but do not define the structures yet.
         // This solves the problem of structures with reference cycles
+        debug!("Declare any structures");
         for (id, ty) in self.mir.type_iter() {
             match ty {
                 MirTypeDef::Structure { path, .. } => xfmr.declare_struct(id, path).unwrap(),
@@ -66,11 +67,11 @@ impl<'a> ProgramTraverser<'a> {
 
     fn map_type<'p, L, V, F: FunctionBuilder<L, V>, P: ProgramBuilder<'p, L, V, F>>(
         &self,
-        id: crate::compiler::mir::TypeId,
+        id: TypeId,
         ty: &MirTypeDef,
         xfmr: &mut P,
     ) {
-        debug!("Traversing types");
+        debug!("Traversing type {:?}", id);
 
         // If this is a type that references other types, make sure those referenced types
         // are defined before transforming this type.


### PR DESCRIPTION
Fixes a bug where the LLVM Generator would fault while adding aggregate types because the types they were composed of had not yet been added to the LLVM Generator's type table.