### PR TITLE
T142 mir2llvm type casting

### DIFF
--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -1669,6 +1669,18 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
                 }
                 .into()
             }
+            (BasicValueEnum::IntValue(iv), BasicTypeEnum::FloatType(tty)) => {
+                // if source is signed
+                if l_signed {
+                    self.program.builder.build_signed_int_to_float(iv, tty, "")
+                // otherwise
+                } else {
+                    self.program
+                        .builder
+                        .build_unsigned_int_to_float(iv, tty, "")
+                }
+                .into()
+            }
             _ => todo!(),
         };
 

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -1693,6 +1693,16 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
                 }
                 .into()
             }
+            (BasicValueEnum::FloatValue(fv), BasicTypeEnum::FloatType(tty)) => {
+                // if upcasting
+                if l_sz < target_sz {
+                    self.program.builder.build_float_ext(fv, tty, "")
+                // otherwise
+                } else {
+                    self.program.builder.build_float_trunc(fv, tty, "")
+                }
+                .into()
+            }
             _ => todo!(),
         };
 

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -1642,24 +1642,18 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
         &self,
         l: BasicValueEnum<'ctx>,
         l_signed: bool,
+        l_sz: u64,
         target: TypeId,
         target_signed: bool,
+        target_sz: u64,
     ) -> Result<BasicValueEnum<'ctx>, TransformerError> {
         let target_ty = self.program.get_type(target)?.into_basic_type().unwrap();
-        println!("target type: {:?}", target_ty);
-        let target_sz = target_ty.size_of().unwrap();
-        println!("sz: {:?}", target_sz);
-        let target_sz = 8;
-
         let l_ty = l.get_type();
-        let l_ty_sz = 8;
-
-        todo!("get the width of the source and target types");
 
         let op = match (l, target_ty) {
             (BasicValueEnum::IntValue(iv), BasicTypeEnum::IntType(tty)) => {
                 // if upcasting
-                if l_ty_sz < target_sz {
+                if l_sz < target_sz {
                     match (l_signed, target_signed) {
                         (false, false) | (false, true) => {
                             self.program.builder.build_int_z_extend(iv, tty, "")

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -1638,6 +1638,19 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
         }
     }
 
+    fn cast(
+        &self,
+        l: BasicValueEnum<'ctx>,
+        l_signed: bool,
+        target: TypeId,
+        target_signed: bool,
+    ) -> Result<BasicValueEnum<'ctx>, TransformerError> {
+        let target_ty = self.program.get_type(target)?;
+        let l_ty = l.get_type();
+
+        todo!()
+    }
+
     fn address_of(&self, a: Location<'ctx>) -> Result<BasicValueEnum<'ctx>, TransformerError> {
         match a {
             Location::Pointer(ptr) => Ok(ptr.into()),

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -1654,7 +1654,6 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
         target_sz: u64,
     ) -> Result<BasicValueEnum<'ctx>, TransformerError> {
         let target_ty = self.program.get_type(target)?.into_basic_type().unwrap();
-        let l_ty = l.get_type();
 
         let op = match (l, target_ty) {
             (BasicValueEnum::IntValue(iv), BasicTypeEnum::IntType(tty)) => {

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -1763,4 +1763,9 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
         let result = unsafe { self.program.builder.build_gep(ptr, &[offset], "").into() };
         Ok(result)
     }
+
+    fn const_null(&self) -> BasicValueEnum<'ctx> {
+        let zero = self.program.context.i64_type().const_zero();
+        zero.into()
+    }
 }

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -1681,6 +1681,18 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
                 }
                 .into()
             }
+            // float to int
+            (BasicValueEnum::FloatValue(fv), BasicTypeEnum::IntType(tty)) => {
+                // if target is signed
+                if target_signed {
+                    self.program.builder.build_float_to_signed_int(fv, tty, "")
+                } else {
+                    self.program
+                        .builder
+                        .build_float_to_unsigned_int(fv, tty, "")
+                }
+                .into()
+            }
             _ => todo!(),
         };
 

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -1703,6 +1703,18 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
                 }
                 .into()
             }
+            // pointer to int
+            (BasicValueEnum::PointerValue(pv), BasicTypeEnum::IntType(tty)) => {
+                self.program.builder.build_ptr_to_int(pv, tty, "").into()
+            }
+            // int to pointer
+            (BasicValueEnum::IntValue(iv), BasicTypeEnum::PointerType(tty)) => {
+                self.program.builder.build_int_to_ptr(iv, tty, "").into()
+            }
+            // pointer to pointer
+            (BasicValueEnum::PointerValue(pv), BasicTypeEnum::PointerType(tty)) => {
+                self.program.builder.build_bitcast(pv, tty, "")
+            }
             _ => todo!(),
         };
 

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -1026,14 +1026,14 @@ mod mir2llvm_tests_visual {
         let r: u64 = compile_and_run(
             "
             fn test() -> u64 {
-                let mut x: i64 := 9;
+                let mut x: i64 := -9;
 
                 return x as u64;
             }
         ",
             "main_test",
         );
-        assert_eq!(9, r);
+        assert_eq!(18446744073709551607, r);
     }
 
     #[test]

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -1037,6 +1037,21 @@ mod mir2llvm_tests_visual {
     }
 
     #[test]
+    fn cast_int_to_float() {
+        let r: f64 = compile_and_run(
+            "
+            fn test() -> f64 {
+                let mut x: i64 := -9;
+
+                return x as f64;
+            }
+        ",
+            "main_test",
+        );
+        assert_eq!(-9.0, r);
+    }
+
+    #[test]
     fn import_function() {
         compile_and_print_llvm(
             "

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -1052,6 +1052,21 @@ mod mir2llvm_tests_visual {
     }
 
     #[test]
+    fn cast_float_to_int() {
+        let r: i64 = compile_and_run(
+            "
+            fn test() -> i64 {
+                let mut x: f64 := -9.0;
+
+                return x as i64;
+            }
+        ",
+            "main_test",
+        );
+        assert_eq!(-9, r);
+    }
+
+    #[test]
     fn import_function() {
         compile_and_print_llvm(
             "

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -1022,6 +1022,21 @@ mod mir2llvm_tests_visual {
     }
 
     #[test]
+    fn cast_int_to_uint() {
+        let r: u64 = compile_and_run(
+            "
+            fn test() -> u64 {
+                let mut x: i64 := 9;
+
+                return x as u64;
+            }
+        ",
+            "main_test",
+        );
+        assert_eq!(9, r);
+    }
+
+    #[test]
     fn import_function() {
         compile_and_print_llvm(
             "

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -1067,6 +1067,36 @@ mod mir2llvm_tests_visual {
     }
 
     #[test]
+    fn cast_float_to_uint() {
+        let r: u64 = compile_and_run(
+            "
+            fn test() -> u64 {
+                let mut x: f64 := -9.0;
+
+                return x as u64;
+            }
+        ",
+            "main_test",
+        );
+        assert_eq!(18446744073709551607, r);
+    }
+
+    #[test]
+    fn cast_float_to_float() {
+        let r: f64 = compile_and_run(
+            "
+            fn test() -> f64 {
+                let mut x: f64 := -9.0;
+
+                return x as f64;
+            }
+        ",
+            "main_test",
+        );
+        assert_eq!(-9.0, r);
+    }
+
+    #[test]
     fn import_function() {
         compile_and_print_llvm(
             "

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -431,6 +431,34 @@ mod mir2llvm_tests_visual {
     }
 
     #[test]
+    fn raw_pointer_cast_from_int() {
+        let text = "
+            fn test() -> i64 {
+                let a: i64 :=  0;
+                let p: *const i64 := a as *const i64;
+
+                return ^p;
+            }
+        ";
+
+        compile_and_print_llvm(text, &[], &[]);
+    }
+
+    #[test]
+    fn raw_pointer_cast_to_int() {
+        let text = "
+            fn test() -> u64 {
+                let a: i64 :=  0;
+                let p: *const i64 := @const a;
+
+                return p as u64;
+            }
+        ";
+
+        compile_and_print_llvm(text, &[], &[]);
+    }
+
+    #[test]
     fn raw_pointer_deref() {
         let text = "
             fn test() -> i64 {

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -459,6 +459,20 @@ mod mir2llvm_tests_visual {
     }
 
     #[test]
+    fn raw_pointer_cast_to_pointer() {
+        let text = "
+            fn test() -> *const u64 {
+                let a: i64 :=  0;
+                let p: *const i64 := @const a;
+
+                return p as *const u64;
+            }
+        ";
+
+        compile_and_print_llvm(text, &[], &[]);
+    }
+
+    #[test]
     fn raw_pointer_deref() {
         let text = "
             fn test() -> i64 {

--- a/src/compiler/mir/builder.rs
+++ b/src/compiler/mir/builder.rs
@@ -396,9 +396,9 @@ impl MirProcedureBuilder {
     }
 
     /// Cast the given expression to the given primitive.
-    pub fn cast(&self, expr: Operand, target: TypeId) -> RValue {
+    pub fn cast(&self, expr: Operand, expr_ty: TypeId, target: TypeId) -> RValue {
         debug!("Cast: {:?}, {:?}", expr, target);
-        RValue::Cast(expr, target)
+        RValue::Cast(expr, expr_ty, target)
     }
 
     /// Terminates by returning to the caller function

--- a/src/compiler/mir/ir.rs
+++ b/src/compiler/mir/ir.rs
@@ -725,7 +725,7 @@ pub enum RValue {
     UnOp(UnOp, Operand),
 
     /// Casting an operand to a new type
-    Cast(Operand, TypeId),
+    Cast(Operand, TypeId, TypeId),
 
     /// Getting the address of a variable in memory.
     AddressOf(LValue),
@@ -737,7 +737,7 @@ impl Display for RValue {
             RValue::Use(o) => format!("Use({})", o),
             RValue::BinOp(op, l, r) => format!("{}({}, {})", op, l, r),
             RValue::UnOp(op, o) => format!("{}({})", op, o),
-            RValue::Cast(v, ty) => format!("{} as {:?}", v, ty),
+            RValue::Cast(v, vty, ty) => format!("{}({:?}) as {:?}", v, vty, ty),
             RValue::AddressOf(o) => format!("AddressOf({})", o),
         };
         f.write_str(&text)

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -157,6 +157,9 @@ pub trait FunctionBuilder<L, V> {
     /// Create a const [`bool`].
     fn const_bool(&self, b: bool) -> V;
 
+    /// Create a const null pointer value.
+    fn const_null(&self) -> V;
+
     /// Create a const [`f64`].
     fn const_f64(&self, f: f64) -> V;
 

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -258,8 +258,10 @@ pub trait FunctionBuilder<L, V> {
         &self,
         l: V,
         l_signed: bool,
+        l_sz: u64,
         target: TypeId,
         target_signed: bool,
+        target_sz: u64,
     ) -> Result<V, TransformerError>;
 
     /// Address of a given Location value.

--- a/src/compiler/mir/ops/transformer.rs
+++ b/src/compiler/mir/ops/transformer.rs
@@ -254,6 +254,15 @@ pub trait FunctionBuilder<L, V> {
     fn i_or(&self, a: V, b: V) -> Result<V, TransformerError>;
 
     /// Address of a given Location value.
+    fn cast(
+        &self,
+        l: V,
+        l_signed: bool,
+        target: TypeId,
+        target_signed: bool,
+    ) -> Result<V, TransformerError>;
+
+    /// Address of a given Location value.
     fn address_of(&self, a: L) -> Result<V, TransformerError>;
 
     /// Use the location pointed to by an address to create an addressable expression.

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -342,7 +342,7 @@ impl<'a, L, V, T: FunctionBuilder<L, V>> FunctionTraverser<'a, L, V, T> {
                     .get_def_string(s)
                     .expect("DefId must refer to a static string literal"),
             ),
-            Constant::Null => todo!(),
+            Constant::Null => self.xfmr.const_null(),
             Constant::SizeOf(_) => todo!(),
         }
     }

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -298,9 +298,13 @@ impl<'a, L, V, T: FunctionBuilder<L, V>> FunctionTraverser<'a, L, V, T> {
                 let l = self.operand(o);
                 // is operand signed
                 let l_signed = self.mir.is_signed(*oty);
+                let l_sz = self.mir.width(*oty).unwrap();
                 // is target type signed
                 let ty_signed = self.mir.is_signed(*target);
-                self.xfmr.cast(l, l_signed, *target, ty_signed).unwrap()
+                let ty_sz = self.mir.width(*target).unwrap();
+                self.xfmr
+                    .cast(l, l_signed, l_sz, *target, ty_signed, ty_sz)
+                    .unwrap()
             }
             RValue::AddressOf(t) => {
                 let l = self.lvalue(t);

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -294,9 +294,13 @@ impl<'a, L, V, T: FunctionBuilder<L, V>> FunctionTraverser<'a, L, V, T> {
                 }
                 .unwrap()
             }
-            RValue::Cast(o, target) => {
+            RValue::Cast(o, oty, target) => {
                 let l = self.operand(o);
-                self.xfmr.cast(l, false, *target, false).unwrap()
+                // is operand signed
+                let l_signed = self.mir.is_signed(*oty);
+                // is target type signed
+                let ty_signed = self.mir.is_signed(*target);
+                self.xfmr.cast(l, l_signed, *target, ty_signed).unwrap()
             }
             RValue::AddressOf(t) => {
                 let l = self.lvalue(t);

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -296,7 +296,7 @@ impl<'a, L, V, T: FunctionBuilder<L, V>> FunctionTraverser<'a, L, V, T> {
             }
             RValue::Cast(o, target) => {
                 let l = self.operand(o);
-                self.xfmr.cast(l, false, target, false).unwrap()
+                self.xfmr.cast(l, false, *target, false).unwrap()
             }
             RValue::AddressOf(t) => {
                 let l = self.lvalue(t);

--- a/src/compiler/mir/ops/traverser.rs
+++ b/src/compiler/mir/ops/traverser.rs
@@ -294,7 +294,10 @@ impl<'a, L, V, T: FunctionBuilder<L, V>> FunctionTraverser<'a, L, V, T> {
                 }
                 .unwrap()
             }
-            RValue::Cast(_, _) => todo!(),
+            RValue::Cast(o, target) => {
+                let l = self.operand(o);
+                self.xfmr.cast(l, false, target, false).unwrap()
+            }
             RValue::AddressOf(t) => {
                 let l = self.lvalue(t);
                 self.xfmr.address_of(l).unwrap()

--- a/src/compiler/mir/project.rs
+++ b/src/compiler/mir/project.rs
@@ -79,9 +79,30 @@ impl MirProject {
                 | super::MirBaseType::U32
                 | super::MirBaseType::U64 => false,
             },
-            MirTypeDef::Array { ty, sz } => false,
-            MirTypeDef::RawPointer { mutable, target } => false,
-            MirTypeDef::Structure { path, def } => false,
+            MirTypeDef::Array { .. } => false,
+            MirTypeDef::RawPointer { .. } => false,
+            MirTypeDef::Structure { .. } => false,
+        }
+    }
+
+    /// Will return the width of the given type, if it is a base type or a pointer
+    pub fn width(&self, ty: TypeId) -> Option<u64> {
+        match self.get_type(ty) {
+            MirTypeDef::Base(base) => match base {
+                super::MirBaseType::Bool | super::MirBaseType::I8 | super::MirBaseType::U8 => {
+                    Some(8)
+                }
+                super::MirBaseType::I16 | super::MirBaseType::U16 => Some(16),
+                super::MirBaseType::I32 | super::MirBaseType::U32 => Some(32),
+                super::MirBaseType::I64 | super::MirBaseType::F64 | super::MirBaseType::U64 => {
+                    Some(64)
+                }
+                super::MirBaseType::Null | super::MirBaseType::StringLiteral => Some(64),
+                super::MirBaseType::Unit => None,
+            },
+            MirTypeDef::Array { .. } => None,
+            MirTypeDef::RawPointer { .. } => Some(64),
+            MirTypeDef::Structure { .. } => None,
         }
     }
 

--- a/src/compiler/mir/project.rs
+++ b/src/compiler/mir/project.rs
@@ -61,6 +61,30 @@ impl MirProject {
         self.types.add(ty)
     }
 
+    /// Returns true if the given type is signed, false otherwise.
+    pub fn is_signed(&self, ty: TypeId) -> bool {
+        match self.get_type(ty) {
+            MirTypeDef::Base(base) => match base {
+                super::MirBaseType::I8
+                | super::MirBaseType::I16
+                | super::MirBaseType::I32
+                | super::MirBaseType::I64
+                | super::MirBaseType::F64 => true,
+                super::MirBaseType::Bool
+                | super::MirBaseType::StringLiteral
+                | super::MirBaseType::Unit
+                | super::MirBaseType::Null
+                | super::MirBaseType::U8
+                | super::MirBaseType::U16
+                | super::MirBaseType::U32
+                | super::MirBaseType::U64 => false,
+            },
+            MirTypeDef::Array { ty, sz } => false,
+            MirTypeDef::RawPointer { mutable, target } => false,
+            MirTypeDef::Structure { path, def } => false,
+        }
+    }
+
     /// Adds a new Structure definition to the [`MirProject`].
     pub fn add_struct_def(
         &mut self,

--- a/src/compiler/mir/test.rs
+++ b/src/compiler/mir/test.rs
@@ -1450,6 +1450,7 @@ pub mod tests {
         let cast = bb.get_stm(1); // x as i32;
         let expected_cast = RValue::Cast(
             Operand::LValue(LValue::Var(VarId::new(0))),
+            project.find_type(&Type::I64).unwrap(),
             project.find_type(&Type::I32).unwrap(),
         );
         let StatementKind::Assign(_, rhs) = cast.kind();

--- a/src/compiler/mir/transform/function.rs
+++ b/src/compiler/mir/transform/function.rs
@@ -234,12 +234,16 @@ impl<'a> FuncTransformer<'a> {
         expr: &Expression<SemanticContext>,
         target: &Type,
     ) -> Operand {
+        let expr_ty = self
+            .project
+            .find_type(expr.context().ty())
+            .expect("Cannot find the given type");
         let expr = self.expression(expr);
         let target = self
             .project
             .find_type(target)
             .expect("Cannot find the given type");
-        let result = self.mir.cast(expr, target);
+        let result = self.mir.cast(expr, expr_ty, target);
         self.mir.temp_store(result, target, ctx.span())
     }
 


### PR DESCRIPTION
Adds support for casting between base types.  Base types includes: integers, floats, and raw pointers.

Additional information was added within the MIR instruction set and the LLVM Builder.  The MIR `Cast` operation needed an easy way to get the type of the source value, so that was added as a field in the Cast tuple.  Further, in order to properly do casting, we needed to be able to check if the types were signed and get the bit-width of the type. Both of these are necessary to properly handle casting (specifically when casting between signed and unsigned types).