### PR TITLE
T152 pointer compare

### DIFF
--- a/src/compiler/ast/ty.rs
+++ b/src/compiler/ast/ty.rs
@@ -251,7 +251,7 @@ impl Type {
 
     pub fn is_unsigned_int(&self) -> bool {
         match self {
-            Type::U8 | Type::U16 | Type::U32 | Type::U64 => true,
+            Type::RawPointer(..) | Type::U8 | Type::U16 | Type::U32 | Type::U64 => true,
             Type::Null
             | Type::I8
             | Type::I16
@@ -268,7 +268,6 @@ impl Type {
             | Type::CoroutineDef(_, _)
             | Type::Coroutine(_)
             | Type::ExternDecl(..)
-            | Type::RawPointer(..)
             | Type::Unknown => false,
         }
     }

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -1137,7 +1137,17 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
 
     fn const_null(&self) -> BasicValueEnum<'ctx> {
         let zero = self.program.context.i64_type().const_zero();
-        zero.into()
+        self.program
+            .builder
+            .build_int_to_ptr(
+                zero,
+                self.program
+                    .context
+                    .i64_type()
+                    .ptr_type(AddressSpace::Generic),
+                "",
+            )
+            .into()
     }
 
     fn const_f64(&self, f: f64) -> BasicValueEnum<'ctx> {
@@ -1335,7 +1345,6 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
                 .builder
                 .build_int_compare(IntPredicate::EQ, l, r, "")
                 .into()),
-            (BasicValueEnum::FloatValue(_), BasicValueEnum::FloatValue(_)) => todo!(),
             (BasicValueEnum::PointerValue(l), BasicValueEnum::PointerValue(r)) => {
                 let result = self.build_ptr_compare(IntPredicate::EQ, l, r).into();
                 Ok(result)
@@ -1357,7 +1366,6 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
                 .builder
                 .build_int_compare(IntPredicate::NE, l, r, "")
                 .into()),
-            (BasicValueEnum::FloatValue(_), BasicValueEnum::FloatValue(_)) => todo!(),
             (BasicValueEnum::PointerValue(l), BasicValueEnum::PointerValue(r)) => {
                 let result = self.build_ptr_compare(IntPredicate::NE, l, r).into();
                 Ok(result)
@@ -1379,8 +1387,6 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
                 .builder
                 .build_int_compare(IntPredicate::SLT, l, r, "")
                 .into()),
-            (BasicValueEnum::FloatValue(_), BasicValueEnum::FloatValue(_)) => todo!(),
-            (BasicValueEnum::PointerValue(_), BasicValueEnum::PointerValue(_)) => todo!(),
             _ => Err(TransformerError::Internal(
                 &LlvmBuilderError::InvalidArithmeticOperands,
             )),
@@ -1398,6 +1404,10 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
                 .builder
                 .build_int_compare(IntPredicate::ULT, l, r, "")
                 .into()),
+            (BasicValueEnum::PointerValue(l), BasicValueEnum::PointerValue(r)) => {
+                let result = self.build_ptr_compare(IntPredicate::ULT, l, r).into();
+                Ok(result)
+            }
             _ => Err(TransformerError::Internal(
                 &LlvmBuilderError::InvalidArithmeticOperands,
             )),
@@ -1432,6 +1442,10 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
                 .builder
                 .build_int_compare(IntPredicate::ULE, l, r, "")
                 .into()),
+            (BasicValueEnum::PointerValue(l), BasicValueEnum::PointerValue(r)) => {
+                let result = self.build_ptr_compare(IntPredicate::ULE, l, r).into();
+                Ok(result)
+            }
             _ => Err(TransformerError::Internal(
                 &LlvmBuilderError::InvalidArithmeticOperands,
             )),
@@ -1466,6 +1480,10 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
                 .builder
                 .build_int_compare(IntPredicate::UGT, l, r, "")
                 .into()),
+            (BasicValueEnum::PointerValue(l), BasicValueEnum::PointerValue(r)) => {
+                let result = self.build_ptr_compare(IntPredicate::UGT, l, r).into();
+                Ok(result)
+            }
             _ => Err(TransformerError::Internal(
                 &LlvmBuilderError::InvalidArithmeticOperands,
             )),
@@ -1500,6 +1518,10 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
                 .builder
                 .build_int_compare(IntPredicate::UGE, l, r, "")
                 .into()),
+            (BasicValueEnum::PointerValue(l), BasicValueEnum::PointerValue(r)) => {
+                let result = self.build_ptr_compare(IntPredicate::UGE, l, r).into();
+                Ok(result)
+            }
             _ => Err(TransformerError::Internal(
                 &LlvmBuilderError::InvalidArithmeticOperands,
             )),

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -1318,7 +1318,18 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
                 .build_int_compare(IntPredicate::EQ, l, r, "")
                 .into()),
             (BasicValueEnum::FloatValue(_), BasicValueEnum::FloatValue(_)) => todo!(),
-            (BasicValueEnum::PointerValue(_), BasicValueEnum::PointerValue(_)) => todo!(),
+            (BasicValueEnum::PointerValue(l), BasicValueEnum::PointerValue(r)) => {
+                let i64ty = self.program.context.i64_type();
+                let li = self.program.builder.build_ptr_to_int(l, i64ty, "");
+                let ri = self.program.builder.build_ptr_to_int(r, i64ty, "");
+
+                let op = self
+                    .program
+                    .builder
+                    .build_int_compare(IntPredicate::EQ, li, ri, "")
+                    .into();
+                Ok(op)
+            }
             _ => Err(TransformerError::Internal(
                 &LlvmBuilderError::InvalidArithmeticOperands,
             )),
@@ -1337,7 +1348,18 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
                 .build_int_compare(IntPredicate::NE, l, r, "")
                 .into()),
             (BasicValueEnum::FloatValue(_), BasicValueEnum::FloatValue(_)) => todo!(),
-            (BasicValueEnum::PointerValue(_), BasicValueEnum::PointerValue(_)) => todo!(),
+            (BasicValueEnum::PointerValue(_), BasicValueEnum::PointerValue(_)) => {
+                let i64ty = self.program.context.i64_type();
+                let li = self.program.builder.build_ptr_to_int(l, i64ty, "");
+                let ri = self.program.builder.build_ptr_to_int(r, i64ty, "");
+
+                let op = self
+                    .program
+                    .builder
+                    .build_int_compare(IntPredicate::NE, li, ri, "")
+                    .into();
+                Ok(op)
+            }
             _ => Err(TransformerError::Internal(
                 &LlvmBuilderError::InvalidArithmeticOperands,
             )),

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -741,6 +741,24 @@ impl<'p, 'module, 'ctx> LlvmFunctionBuilder<'p, 'module, 'ctx> {
             )
             .unwrap();
     }
+
+    fn build_ptr_compare(
+        &self,
+        op: IntPredicate,
+        l: PointerValue<'ctx>,
+        r: PointerValue<'ctx>,
+    ) -> BasicValueEnum<'ctx> {
+        let i64ty = self.program.context.i64_type();
+        let li = self.program.builder.build_ptr_to_int(l, i64ty, "");
+        let ri = self.program.builder.build_ptr_to_int(r, i64ty, "");
+
+        let op = self
+            .program
+            .builder
+            .build_int_compare(op, li, ri, "")
+            .into();
+        op
+    }
 }
 
 impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
@@ -1319,16 +1337,8 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
                 .into()),
             (BasicValueEnum::FloatValue(_), BasicValueEnum::FloatValue(_)) => todo!(),
             (BasicValueEnum::PointerValue(l), BasicValueEnum::PointerValue(r)) => {
-                let i64ty = self.program.context.i64_type();
-                let li = self.program.builder.build_ptr_to_int(l, i64ty, "");
-                let ri = self.program.builder.build_ptr_to_int(r, i64ty, "");
-
-                let op = self
-                    .program
-                    .builder
-                    .build_int_compare(IntPredicate::EQ, li, ri, "")
-                    .into();
-                Ok(op)
+                let result = self.build_ptr_compare(IntPredicate::EQ, l, r).into();
+                Ok(result)
             }
             _ => Err(TransformerError::Internal(
                 &LlvmBuilderError::InvalidArithmeticOperands,
@@ -1349,16 +1359,8 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
                 .into()),
             (BasicValueEnum::FloatValue(_), BasicValueEnum::FloatValue(_)) => todo!(),
             (BasicValueEnum::PointerValue(l), BasicValueEnum::PointerValue(r)) => {
-                let i64ty = self.program.context.i64_type();
-                let li = self.program.builder.build_ptr_to_int(l, i64ty, "");
-                let ri = self.program.builder.build_ptr_to_int(r, i64ty, "");
-
-                let op = self
-                    .program
-                    .builder
-                    .build_int_compare(IntPredicate::NE, li, ri, "")
-                    .into();
-                Ok(op)
+                let result = self.build_ptr_compare(IntPredicate::NE, l, r).into();
+                Ok(result)
             }
             _ => Err(TransformerError::Internal(
                 &LlvmBuilderError::InvalidArithmeticOperands,

--- a/src/compiler/llvm/mir.rs
+++ b/src/compiler/llvm/mir.rs
@@ -1348,7 +1348,7 @@ impl<'p, 'module, 'ctx> FunctionBuilder<Location<'ctx>, BasicValueEnum<'ctx>>
                 .build_int_compare(IntPredicate::NE, l, r, "")
                 .into()),
             (BasicValueEnum::FloatValue(_), BasicValueEnum::FloatValue(_)) => todo!(),
-            (BasicValueEnum::PointerValue(_), BasicValueEnum::PointerValue(_)) => {
+            (BasicValueEnum::PointerValue(l), BasicValueEnum::PointerValue(r)) => {
                 let i64ty = self.program.context.i64_type();
                 let li = self.program.builder.build_ptr_to_int(l, i64ty, "");
                 let ri = self.program.builder.build_ptr_to_int(r, i64ty, "");

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -505,6 +505,22 @@ mod mir2llvm_tests_visual {
     }
 
     #[test]
+    fn raw_pointer_lt() {
+        let text = "
+            fn test() -> bool {
+                let a: i64 :=  6;
+                let p: *const i64 := @const a;
+                let p2: *const i64 := @const a;
+
+                return p < p2;
+            }
+        ";
+
+        let r: bool = compile_and_run(text, "main_test");
+        assert_eq!(false, r);
+    }
+
+    #[test]
     fn raw_pointer_deref() {
         let text = "
             fn test() -> i64 {

--- a/src/compiler/llvm/mir_test.rs
+++ b/src/compiler/llvm/mir_test.rs
@@ -473,6 +473,38 @@ mod mir2llvm_tests_visual {
     }
 
     #[test]
+    fn raw_pointer_equal() {
+        let text = "
+            fn test() -> bool {
+                let a: i64 :=  6;
+                let p: *const i64 := @const a;
+                let p2: *const i64 := @const a;
+
+                return p == p2;
+            }
+        ";
+
+        let r: bool = compile_and_run(text, "main_test");
+        assert!(r);
+    }
+
+    #[test]
+    fn raw_pointer_not_equal() {
+        let text = "
+            fn test() -> bool {
+                let a: i64 :=  6;
+                let p: *const i64 := @const a;
+                let p2: *const i64 := @const a;
+
+                return p != p2;
+            }
+        ";
+
+        let r: bool = compile_and_run(text, "main_test");
+        assert_eq!(false, r);
+    }
+
+    #[test]
     fn raw_pointer_deref() {
         let text = "
             fn test() -> i64 {


### PR DESCRIPTION
This implements pointer comparison operators in LLVM generation.

This also fixes a bug where the `null` value was not being properly converted to a `PointerValue`, this caused comparisons between pointers and null to fail.